### PR TITLE
Add claude stow package for CLAUDE.md and skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ atom.symlink/themes
 git/gitconfig.symlink
 
 zsh/config.symlink/configstore/*
+
+# The user's global ~/.gitignore ignores .claude/ everywhere; un-ignore the
+# tracked stow package contents so this repo can manage them.
+!stow-packages/claude/.claude/
+!stow-packages/claude/.claude/**

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ Each directory in `stow-packages/` represents a configuration package:
 - **tmux**: Terminal multiplexer configuration (.tmux.conf)
 - **asdf**: Version manager configuration (.tool-versions)
 - **atuin**: Shell history manager configuration
+- **claude**: Claude Code user config (CLAUDE.md and skills/)
 
 ### Package Management
 
 Install specific packages:
+
 ```sh
 cd ~/.dotfiles/stow-packages
 stow nvim     # Install Neovim config to ~/.config/nvim/
@@ -48,17 +50,20 @@ stow git      # Install git config to ~/.gitconfig and ~/.gitignore
 ```
 
 Remove packages:
+
 ```sh
 cd ~/.dotfiles/stow-packages
 stow -D nvim  # Remove Neovim config symlinks
 ```
 
 Install all packages:
+
 ```sh
 ~/.dotfiles/stow-packages/bootstrap.sh
 ```
 
 Remove all packages:
+
 ```sh
 ~/.dotfiles/stow-packages/unstow.sh
 ```
@@ -81,17 +86,20 @@ Everything else (including the package manager on macOS) is handled by `install.
 ## Installation
 
 1. **Clone this repository**:
+
    ```sh
    git clone https://github.com/ian-bartholomew/dotfiles.git ~/.dotfiles
    cd ~/.dotfiles
    ```
 
 2. **Install system dependencies**:
+
    ```sh
    ./install.sh
    ```
 
 3. **Install configurations**:
+
    ```sh
    stow-packages/bootstrap.sh
    ```

--- a/stow-packages/claude/.claude/CLAUDE.md
+++ b/stow-packages/claude/.claude/CLAUDE.md
@@ -1,0 +1,53 @@
+# User Instructions for Claude
+
+Always check the wiki (`~/Documents/Work/wiki/_index.md`) before web search, Context7, or general knowledge. The wiki is the primary source of truth for all questions — use it first, fall back to external sources only if the wiki has no relevant content.
+
+Always use Context7 when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
+
+## Git Conventions
+
+- Branch names: `<ticket-id>-<ticket-name>`, e.g. `FANDEVX-2592-fbg-fanflow-kafka-dev`
+- Worktrees: always create git worktrees in `EnterWorktree`'s default location — `<repo-root>/.claude/worktrees/<branch-name>` (the `.claude/` directory at the repo root, NOT `~/.claude/`). Do not override this default. Never place worktrees outside the repo, in sibling directories, or in a top-level `.worktrees/` directory. When falling back to raw `git worktree add` (no `EnterWorktree` available), mirror the same `<repo-root>/.claude/worktrees/<branch-name>` path.
+- Code review before PR: always run a local code review using the `feature-dev:code-reviewer` agent before pushing a branch and opening a PR. Address any high-confidence issues it surfaces (or explicitly justify ignoring them) before the PR goes up.
+
+## GitHub Identity
+
+- For any repo in the `fanatics-gaming` org, work always happens under the `ian-at-fes` GitHub identity. Personal account is `ian-bartholomew`.
+- Before any repo-scoped query, run `gh auth status` and confirm `ian-at-fes` is the active account.
+- Do NOT use `--author=@me` in `gh search prs` / `gh search issues` — it resolves to the personal account even when `ian-at-fes` is active. Use `--author=ian-at-fes` explicitly.
+- Prefer the `gh` CLI over the GitHub MCP for queries against `fanatics-gaming` org repos — the MCP has shown gaps in org-scoped PR visibility.
+- For SSH, the `github-work` host alias is the work identity; never use the bare `github.com` remote.
+
+## Confluence
+
+For all Confluence page edits, use the `claude-atlassian:confluence-editor` skill.
+
+## JIRA Defaults
+
+When creating or working with JIRA tickets:
+
+- Default to the FanApp DevX space
+- Assign tickets to the FES Platform team
+- Always use the `fes-platform-jira-tickets` skill (or `/fes-platform-jira-tickets`) when creating, filing, or generating any JIRA tickets (Epics, Stories, Bugs in FANDEVX; Features in FESFEAT). Do not bypass it with direct MCP calls.
+- Always use the `/start-ticket` skill when starting work on a JIRA ticket — it fetches ticket details, creates the worktree on a properly named branch, and produces an initial plan.
+- Bugs cannot be children of Stories — both are hierarchy level 0. Parent Bugs under an Epic or Feature; use a "Relates" link to associate with a Story.
+- Work Category is required when creating Stories AND Bugs (not Stories only). Don't omit it on bug creation.
+
+## Projects
+
+When working on anything tied to a project under `~/Documents/Work/projects/<project>/`, always append an entry to that project's `log.md` capturing what was done, decisions made, and any follow-ups. Update `log.md` as work progresses, not just at the end of the session.
+
+## AWS Guidance
+
+- Prefer the AWS MCP Server for AWS interactions — it provides sandboxed execution, observability, and audit logging. If unavailable, use the AWS CLI directly.
+- Prefer the AWS Documentation Server for AWS documentation questions.
+- Before starting a task, check whether a relevant AWS skill is available. Load the skill with `retrieve_skill` and prefer its guidance over general knowledge.
+- When uncertain about specific AWS details (API parameters, permissions, limits, error codes), verify against documentation via the AWS Documentation MCP server, rather than guessing. State uncertainty explicitly if you cannot confirm.
+- Do not directly create infrastructure directly, only through Terraform
+- When working with or creating infrastructure, follow AWS Well-Architected Framework principles. If a plan violates any of the Well-Architected Framework, call it out
+- Do not use em dashes in AWS resource names or descriptions. Use hyphens instead.
+- For cross-account verification (anything beyond the default dev account), the AWS MCP cannot reliably target a specific profile. Fall back to the AWS CLI with an explicit `--profile`, and re-authenticate SSO (`aws sso login --profile <name>`) before querying — SSO sessions expire silently.
+
+## Verification
+
+Before reporting work as done — implementation, fix, apply, merge, anything — run the relevant verification command and quote the output. If verification isn't possible (e.g. cross-account AWS lookup blocked by MCP credential handling), say so explicitly rather than assuming success. Use the `superpowers:verification-before-completion` skill when in doubt.

--- a/stow-packages/claude/.claude/skills/daily-standup/SKILL.md
+++ b/stow-packages/claude/.claude/skills/daily-standup/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: daily-standup
+description: This skill should be used when the user asks to "daily standup", "standup", "run standup", "make my standup", "generate my standup", or runs "/daily-standup". Synthesizes the classic three-bucket standup (what I did / what I'm going to do / blockers) from the wiki log, project logs, meeting summaries, the Obsidian daily note, JIRA, Todoist (#work), and Slack, then writes it into today's Obsidian daily note. Blockers are inferred from sources — no interactive prompt.
+version: 0.2.0
+allowed-tools:
+  [
+    Bash,
+    Read,
+    mcp__plugin_fbg-core_atlassian__searchJiraIssuesUsingJql,
+    mcp__claude_ai_Slack__slack_search_public_and_private,
+    Skill,
+  ]
+---
+
+# Daily Standup Skill
+
+Generate a daily standup section in today's Obsidian daily note. Three
+buckets, source-attributed, idempotent — gather from the wiki log,
+project logs, meeting summaries, Obsidian daily notes, JIRA, Todoist
+(`#work`), and Slack; infer blockers from those sources; emit the section
+via a deterministic Python renderer.
+
+## Purpose
+
+The morning standup is always the same shape, but the inputs are scattered
+across the wiki, JIRA, Todoist, the daily note, and Slack. This skill stitches
+them together so the user can paste a complete standup into Slack (or read it
+from Obsidian) without manually correlating sources every morning. Blockers
+are inferred from JIRA status, project logs, meeting notes, and the daily
+note — the skill never prompts.
+
+Layout is owned by `render.py` next to this file. The model gathers raw data,
+normalizes it to a JSON contract, and pipes it to `render.py`. The model
+never composes the standup markdown by hand.
+
+## When to Use
+
+- User explicitly runs `/daily-standup`
+- User says "daily standup", "standup", "run standup", "make my standup", "generate my standup"
+
+## When NOT to Use
+
+- Morning snapshot of PRs + JIRA + all Todoist — use `/start-of-day`
+- End-of-day capture (meetings, Slack learnings, wiki compile) — use `/end-of-day`
+- Just see today's Todoist — `td today` directly
+- Just see open JIRA — Atlassian MCP / board directly
+
+## Pipeline
+
+```
+  Compute lookback date  →  Parallel fetch  →  Normalize to JSON
+                                                       │
+                                                       ▼
+                                          render.py → markdown block
+                                                       │
+                                                       ▼
+                                       Upsert into today's daily note
+                                                       │
+                                                       ▼
+                                          One confirmation line, exit
+```
+
+## Prerequisites
+
+- **Obsidian app running** with Daily Notes enabled (so `obsidian daily` /
+  `obsidian daily:path` work). Full reference: <https://help.obsidian.md/cli>.
+- **Atlassian MCP** (`mcp__plugin_fbg-core_atlassian__searchJiraIssuesUsingJql`).
+- **Todoist CLI (`td`) authed.** Fallback absolute path: `/opt/homebrew/bin/td`.
+- **Slack MCP** (`mcp__claude_ai_Slack__*`). Best-effort — if unauthed, skip
+  the Slack signal and continue.
+- Working directory is the Obsidian vault (`~/Documents/Work`) so relative
+  reads of `wiki/_log.md`, `projects/`, and `meetings/` resolve.
+
+## Process Flow
+
+### Step 1: Compute the lookback window
+
+`today_date` = today (ISO `YYYY-MM-DD`).
+`lookback_date` rule:
+
+- If today is **Monday** → previous **Friday** (today minus 3 days).
+- Otherwise → today minus 1 day.
+
+Capture both the ISO date and the weekday label (`Friday`, `Monday`, …) so the
+section header can read `_Since Friday 2026-05-15 → Monday 2026-05-18_`.
+
+A one-liner that does this:
+
+```bash
+python3 -c "
+from datetime import date, timedelta
+t = date.today()
+delta = 3 if t.weekday() == 0 else 1
+y = t - timedelta(days=delta)
+print(f'lookback_date={y.isoformat()} lookback_label={y.strftime(\"%A\")} today_date={t.isoformat()} today_label={t.strftime(\"%A\")}')
+"
+```
+
+### Step 2: Locate today's daily note
+
+```bash
+obsidian daily                           # ensure today's note exists
+DAILY_NOTE_PATH="$(obsidian daily:path)" # canonical absolute path
+```
+
+Never construct the path manually. If `obsidian daily` exits non-zero, see §Error Handling.
+
+### Step 3: Fetch all sources in parallel
+
+Issue these in a single assistant message so they execute concurrently.
+
+1. **Bash — wiki activity log:** grep entries dated within the lookback day,
+   but **exclude EOD and wiki-ingestion actions** — these are background
+   maintenance, not standup-worthy work.
+
+   ```bash
+   grep -nE "^## \\[$LOOKBACK_DATE\\]" wiki/_log.md \
+     | grep -vE "\\] (end-of-day|compile|ingest|lint|migration) \\|" \
+     || true
+   ```
+
+   Then read ~30 lines after each match to capture the entry body. Skip any
+   matched entry whose action is one of `end-of-day`, `compile`, `ingest`,
+   `lint`, or `migration`. Keep `research`, `query`, `archive`, and any other
+   user-facing actions.
+
+2. **Bash — project logs:** glob and read each active project's log.
+
+   ```bash
+   ls projects/*/log.md 2>/dev/null
+   ```
+
+   For each, `grep -nE "^## \\[?$LOOKBACK_DATE" <file>` to find entries from
+   the lookback day, then read their bodies. Capture the project name from
+   the directory.
+
+3. **Bash — meeting summaries:** glob the lookback day's meeting folders.
+
+   ```bash
+   ls -d meetings/$LOOKBACK_DATE-*/ 2>/dev/null
+   ```
+
+   For each, read `summary-*.md` (or `summary.md`). Pull the meeting title
+   from the folder name and a one-line summary from the file.
+
+4. **Bash — today's daily note:** read `$DAILY_NOTE_PATH`. Look for any
+   user-authored "Plan" / "Today" / "Blockers" sections to lift verbatim
+   into "Today" / "Blockers" buckets respectively.
+
+5. **Atlassian MCP — JIRA In Progress:**
+
+   ```jql
+   assignee = currentUser() AND status = "In Progress" ORDER BY updated DESC
+   ```
+
+6. **Atlassian MCP — JIRA Blocked:**
+
+   ```jql
+   assignee = currentUser() AND status in (Blocked, "On Hold", Waiting) ORDER BY updated DESC
+   ```
+
+7. **Bash — Todoist `#work` due today + overdue:**
+
+   ```bash
+   td today --json
+   ```
+
+   Filter the result to tasks whose project name is `work` (or any task whose
+   `project_id` matches `#work`). Include overdue items.
+
+8. **Slack MCP — messages I sent in the lookback window.** Best-effort: a
+   401/permission error means skip, don't fail the run.
+
+   ```text
+   slack_search_public_and_private query: "from:@me after:<LOOKBACK_DATE-1d> before:<TODAY_DATE+1d>"
+   ```
+
+   Take the top ~20 results; collapse near-duplicates (same channel, same
+   thread root) into a single bullet noting the channel and topic.
+
+### Step 4: Normalize to JSON
+
+Produce a single JSON blob matching the contract documented in `render.py`:
+
+```json
+{
+  "lookback_date":  "2026-05-15",
+  "lookback_label": "Friday",
+  "today_date":     "2026-05-18",
+  "today_label":    "Monday",
+  "did":      [ { "text": "...", "ref": "FANDEVX-1234", "url": "https://...", "source": "jira" }, ... ],
+  "will_do":  [ ... ],
+  "blockers": [ ... ]
+}
+```
+
+Bucket assignment rules:
+
+- **did** — every wiki log / project log / meeting / Slack signal from the
+  lookback window; any closed/resolved JIRA tickets the user worked on.
+  Source one of: `jira`, `project`, `log`, `meeting`, `slack`.
+- **will_do** — JIRA In Progress assigned to user; Todoist `#work` tasks
+  (today + overdue); free-text "Plan" / "Today" section in today's daily
+  note; up to 3 LLM-inferred continuations from yesterday's open threads
+  (project log "follow-ups", meeting "action items"). Source one of:
+  `jira`, `todoist`, `daily-note`, `inferred`.
+- **blockers** — JIRA tickets in Blocked / On Hold / Waiting; daily note
+  "Blockers" section if present; LLM scan of recent project log / meeting
+  notes for "blocker", "waiting on", "stuck on", "blocked by", "depends on",
+  "awaiting" language. Source one of: `jira`, `daily-note`, `inferred`.
+  All non-JIRA / non-daily-note blockers are inferred — the skill does not
+  prompt for manual blocker input.
+
+Cap inferred bullets at **3 per bucket** to keep noise down. Mark every
+inferred bullet `source: "inferred"` so the user can prune in Obsidian.
+
+For JIRA bullets, set `status` to the JIRA status string (e.g. `"In Progress"`,
+`"Blocked"`) so the renderer can emit the matching status emoji.
+
+**Bullet text must be Slack-brief.** Aim for **≤ 12 words** per `text`.
+Prefer verb-led fragments over full sentences:
+
+- ✅ `"Shipped Karpenter migration for load-testing env"`
+- ❌ `"I shipped the Karpenter migration for the load-testing environment, which involved …"`
+
+Strip ticket keys from the `text` (they go in `ref`). Strip URLs from the
+`text` (they go in `url`). One idea per bullet — split if you find yourself
+writing "and".
+
+Write the JSON to `/tmp/daily-standup.json`.
+
+### Step 5: Render
+
+Default is brief mode (Slack-friendly): bare JIRA keys, no source-of-truth
+italic suffix, no date-range header. Pass `--verbose` for the Obsidian-only
+format with markdown links and source labels.
+
+```bash
+# Brief (default — Slack paste)
+python3 ~/.claude/skills/daily-standup/render.py --input /tmp/daily-standup.json > /tmp/daily-standup.md
+
+# Verbose (Obsidian-friendly)
+python3 ~/.claude/skills/daily-standup/render.py --input /tmp/daily-standup.json --verbose > /tmp/daily-standup.md
+```
+
+If the user asks for "verbose" / "with links" / "for obsidian", pass
+`--verbose`. Otherwise default to brief.
+
+### Step 6: Upsert into today's daily note
+
+The rendered block is delimited by `<!-- standup:start -->` / `<!-- standup:end -->`.
+Idempotent algorithm:
+
+1. Read `$DAILY_NOTE_PATH`.
+2. If the file already contains `<!-- standup:start -->`, replace everything
+   from the `## Daily Standup` heading through the `<!-- standup:end -->`
+   marker with the new block.
+3. Otherwise, append the new block to the end of the file (preceded by a
+   blank line).
+4. Write the file back atomically.
+
+A safe shell implementation:
+
+```bash
+python3 - "$DAILY_NOTE_PATH" /tmp/daily-standup.md <<'PY'
+import sys, re, pathlib
+note = pathlib.Path(sys.argv[1])
+new_block = pathlib.Path(sys.argv[2]).read_text().rstrip("\n") + "\n"
+text = note.read_text() if note.exists() else ""
+pattern = re.compile(r"## Daily Standup\n.*?<!-- standup:end -->\n?", re.DOTALL)
+if pattern.search(text):
+    text = pattern.sub(new_block, text)
+else:
+    if text and not text.endswith("\n"):
+        text += "\n"
+    if text:
+        text += "\n"
+    text += new_block
+note.write_text(text)
+print(note)
+PY
+```
+
+### Step 7: Confirm and exit
+
+Print one line:
+
+```
+✅ Daily standup written to: /Users/.../05-18-2026.md
+```
+
+Do not loop. Do not summarise the buckets. The user reads/edits the section
+directly in Obsidian.
+
+## Error Handling
+
+- **`obsidian daily` fails** — print the underlying error verbatim and exit.
+  The Obsidian app probably isn't running.
+- **Atlassian MCP fails** — render `did` / `will_do` / `blockers` from the
+  remaining sources; JIRA-derived bullets simply won't appear.
+- **`td today` fails** — same: drop the Todoist source, keep going.
+- **Slack MCP fails or returns 401** — same: silently drop the Slack signal.
+  Do not prompt the user; auth is out of scope for this skill.
+- **No sources matched at all** — the renderer emits empty-state placeholders
+  (`_No activity captured for the lookback window._` etc.) so the section
+  is still well-formed.
+
+## Out of Scope (v0.1)
+
+- Posting to Slack directly. v0.1 writes only to the daily note; copy/paste
+  is the user's call.
+- Holiday / PTO-aware lookback. If today is the day after a holiday, the
+  lookback may miss work. Re-run with a future `--since YYYY-MM-DD` override
+  if that ever becomes a problem.
+- Multi-day lookback. v0.1 looks back one workday only.

--- a/stow-packages/claude/.claude/skills/daily-standup/render.py
+++ b/stow-packages/claude/.claude/skills/daily-standup/render.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Render the /daily-standup section from a single normalized JSON blob.
+
+The model gathers raw sources (wiki log, project logs, meeting summaries,
+JIRA, Todoist, Slack, Obsidian daily note), normalizes everything into the
+three-bucket contract below, writes it to a JSON file, and invokes this
+script. The model never composes the standup markdown by hand.
+
+JSON contract (read from --input or stdin):
+
+  {
+    "lookback_date": "2026-05-15",          # ISO date of "yesterday" (workday)
+    "lookback_label": "Friday",             # Human label for the section header
+    "today_date":    "2026-05-18",
+    "today_label":   "Monday",
+    "did":      [ { ...bullet... }, ... ],
+    "will_do":  [ { ...bullet... }, ... ],
+    "blockers": [ { ...bullet... }, ... ]
+  }
+
+Bullet shape:
+
+  {
+    "text":   "Shipped load testing env Karpenter migration",  # required
+    "ref":    "FANDEVX-1234",          # optional JIRA / PR / task key
+    "url":    "https://...",           # optional link target
+    "source": "jira|project|log|meeting|slack|todoist|daily-note|inferred|input",
+    "status": "In Progress"            # optional, only used for "Today" / "Blockers"
+  }
+
+Output: the full `## Daily Standup` ... `<!-- standup:end -->` block on stdout
+with a trailing newline. Idempotent: callers replace anything between the
+markers in today's Obsidian daily note.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Status emoji map mirrors start-of-day so the daily note reads consistently.
+STATUS_EMOJI = {
+    "to do": "📋", "backlog": "📋", "open": "📋", "new": "📋",
+    "in progress": "🚧", "in development": "🚧",
+    "in review": "👀", "code review": "👀", "qa": "👀",
+    "blocked": "🛑", "on hold": "🛑", "waiting": "🛑",
+    "done": "✅", "closed": "✅", "resolved": "✅",
+}
+
+# Source labels used for the `· _source_` italic suffix on each bullet.
+SOURCE_LABEL = {
+    "jira": "jira",
+    "project": "project",
+    "log": "log",
+    "meeting": "meeting",
+    "slack": "slack",
+    "todoist": "todoist",
+    "daily-note": "daily-note",
+    "inferred": "inferred",
+    "input": "input",
+}
+
+# Render-order priority for each bucket. Bullets within a bucket are stably
+# grouped by source so the section reads JIRA-first, then project context,
+# then external signals, then inferred items.
+DID_ORDER     = ["jira", "project", "log", "meeting", "slack", "inferred"]
+WILLDO_ORDER  = ["jira", "todoist", "daily-note", "inferred"]
+BLOCKER_ORDER = ["jira", "daily-note", "input", "inferred"]
+
+
+def status_prefix(status: str | None) -> str:
+    if not status:
+        return ""
+    return STATUS_EMOJI.get(status.strip().lower(), "")
+
+
+def render_bullet(b: dict, verbose: bool) -> str:
+    text = b.get("text") or "(no text)"
+    ref = b.get("ref") or ""
+    url = b.get("url") or ""
+    source = b.get("source") or ""
+    status = b.get("status") or ""
+
+    head = ""
+    sp = status_prefix(status)
+    if sp:
+        head = f"{sp} "
+
+    # Verbose: [REF](url) markdown link with backtick fallback, and source suffix.
+    # Brief:   bare REF (Slack-friendly; JIRA app autolinks if installed), no suffix.
+    if verbose:
+        if ref and url:
+            anchor = f"[{ref}]({url}) "
+        elif ref:
+            anchor = f"`{ref}` "
+        else:
+            anchor = ""
+        label = SOURCE_LABEL.get(source)
+        suffix = f" · _{label}_" if label else ""
+    else:
+        anchor = f"{ref} " if ref else ""
+        suffix = ""
+
+    return f"- {head}{anchor}{text}{suffix}".rstrip()
+
+
+def render_bucket(title: str, bullets: list[dict], order: list[str], empty_msg: str, verbose: bool) -> str:
+    out = [f"### {title}", ""]
+    if not bullets:
+        out.append(f"_{empty_msg}_")
+        return "\n".join(out)
+
+    # Group by source while preserving incoming order inside each group.
+    by_source: dict[str, list[dict]] = {}
+    for b in bullets:
+        by_source.setdefault(b.get("source") or "", []).append(b)
+
+    seen: set[str] = set()
+    for src in order:
+        for b in by_source.get(src, []):
+            out.append(render_bullet(b, verbose))
+        seen.add(src)
+    # Any bullets with unknown / missing source render last so nothing is dropped.
+    for src, group in by_source.items():
+        if src in seen:
+            continue
+        for b in group:
+            out.append(render_bullet(b, verbose))
+    return "\n".join(out)
+
+
+def render(payload: dict, verbose: bool) -> str:
+    lookback_date = payload.get("lookback_date") or ""
+    lookback_label = payload.get("lookback_label") or ""
+    today_date = payload.get("today_date") or ""
+    today_label = payload.get("today_label") or ""
+
+    header_bits = []
+    if lookback_label and lookback_date:
+        header_bits.append(f"{lookback_label} {lookback_date}")
+    elif lookback_date:
+        header_bits.append(lookback_date)
+    if today_label and today_date:
+        header_bits.append(f"{today_label} {today_date}")
+    elif today_date:
+        header_bits.append(today_date)
+    # Date-range header is verbose-only — Slack readers already know what day it is.
+    header_line = "_Since " + " → ".join(header_bits) + "_" if (verbose and header_bits) else ""
+
+    blocks = [
+        "## Daily Standup",
+        "",
+        "<!-- standup:start -->",
+        "",
+    ]
+    if header_line:
+        blocks.extend([header_line, ""])
+
+    blocks.append(render_bucket(
+        "Yesterday",
+        payload.get("did") or [],
+        DID_ORDER,
+        "No activity captured for the lookback window.",
+        verbose,
+    ))
+    blocks.append("")
+    blocks.append(render_bucket(
+        "Today",
+        payload.get("will_do") or [],
+        WILLDO_ORDER,
+        "No planned work captured.",
+        verbose,
+    ))
+    blocks.append("")
+    blocks.append(render_bucket(
+        "Blockers",
+        payload.get("blockers") or [],
+        BLOCKER_ORDER,
+        "None.",
+        verbose,
+    ))
+    blocks.append("")
+    blocks.append("<!-- standup:end -->")
+    return "\n".join(blocks) + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--input", type=Path, default=None,
+        help="Path to the normalized JSON blob. If omitted, read from stdin.",
+    )
+    p.add_argument(
+        "--verbose", action="store_true",
+        help="Verbose mode: markdown JIRA links, source-of-truth suffix, "
+             "and the date-range header. Default is brief (Slack-friendly).",
+    )
+    args = p.parse_args()
+
+    if args.input is not None:
+        try:
+            payload = json.loads(args.input.read_text())
+        except FileNotFoundError:
+            print(f"render.py: input not found: {args.input}", file=sys.stderr)
+            return 2
+        except json.JSONDecodeError as e:
+            print(f"render.py: invalid JSON in {args.input.name}: {e}", file=sys.stderr)
+            return 2
+    else:
+        try:
+            payload = json.load(sys.stdin)
+        except json.JSONDecodeError as e:
+            print(f"render.py: invalid JSON on stdin: {e}", file=sys.stderr)
+            return 2
+
+    sys.stdout.write(render(payload, verbose=args.verbose))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stow-packages/claude/.claude/skills/deploy-workflow/SKILL.md
+++ b/stow-packages/claude/.claude/skills/deploy-workflow/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: deploy-workflow
+description: >
+  Use when the user asks to "find deployments", "open deploy workflow",
+  "check pending deploys", "deploy-workflow", "what's waiting to deploy",
+  or wants to find and open pending GitHub Actions deployment workflows
+  for the fanapp-terraform repo.
+argument-hint: [time-window] [--domain <domain>] [--env <env>] [--all] [--branch <branch>]
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+# Deploy Workflow
+
+Find your pending Terraform deployment workflows in `fanatics-gaming/fanapp-terraform` and open them in GitHub Actions.
+
+## Arguments
+
+- **No arguments:** Your waiting workflows on `main` created in the last 1 hour
+- **Time window:** `30m`, `1h` (default), `2h`, `1d` — lookback duration. Format: `<N><unit>` where unit is `m` (minutes), `h` (hours), `d` (days). Convert to ISO 8601 timestamp for the `created` API filter.
+- **`--domain <name>`:** Filter by domain (e.g., `fes-loyalty`, `fanapp`, `fes-streaming`)
+- **`--env <name>`:** Filter by environment (e.g., `dev`, `prod`, `test`)
+- **`--all`:** Show all users' waiting runs, not just yours
+- **`--branch <name>`:** Override branch filter (default: `main`)
+
+## Workflow
+
+```dot
+digraph deploy {
+    "Fetch waiting runs via GH API" [shape=box];
+    "Extract workflow name from path" [shape=box];
+    "Apply --domain / --env filters" [shape=box];
+    "Matches found?" [shape=diamond];
+    "Present list via AskUserQuestion" [shape=box];
+    "Report no matches" [shape=box];
+    "Open selected in browser" [shape=doublecircle];
+
+    "Fetch waiting runs via GH API" -> "Extract workflow name from path";
+    "Extract workflow name from path" -> "Apply --domain / --env filters";
+    "Apply --domain / --env filters" -> "Matches found?";
+    "Matches found?" -> "Present list via AskUserQuestion" [label="yes"];
+    "Matches found?" -> "Report no matches" [label="no"];
+    "Present list via AskUserQuestion" -> "Open selected in browser";
+}
+```
+
+### Step 1: Fetch Waiting Runs
+
+Calculate the `created` cutoff timestamp: default is 1 hour ago, or parse the time window argument. Use `date -u -v-<N><unit> +%Y-%m-%dT%H:%M:%SZ` to compute the ISO 8601 timestamp (e.g., `date -u -v-1H` for 1 hour, `date -u -v-2H` for 2 hours, `date -u -v-30M` for 30 minutes, `date -u -v-1d` for 1 day).
+
+Use the GitHub API directly (not `gh run list`) to support actor and time filtering:
+
+```bash
+SINCE=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)
+gh api "repos/fanatics-gaming/fanapp-terraform/actions/runs?status=waiting&branch=main&actor=ian-at-fes&per_page=50&created=>=$SINCE" --jq '[.workflow_runs[] | {id: .id, path: .path, created: .created_at}]'
+```
+
+- If time window arg provided (e.g., `2h`, `30m`, `1d`): adjust the `-v` flag accordingly
+- If `--all` provided: remove `&actor=ian-at-fes` from the query
+- If `--branch` provided: replace `main` with that value
+
+### Step 2: Extract Workflow Name
+
+The `path` field contains the workflow file: `.github/workflows/<name>.yaml`
+
+Strip the prefix and `.yaml` suffix to get a human-readable name. Examples:
+
+| path | display name |
+|---|---|
+| `.github/workflows/fes-streaming-dev.yaml` | `fes-streaming-dev` |
+| `.github/workflows/fes-datadog_prod_org.yaml` | `fes-datadog_prod_org` |
+| `.github/workflows/prod_infra.yaml` | `prod_infra` |
+| `.github/workflows/fes-loyalty-infra-dev.yaml` | `fes-loyalty-infra-dev` |
+| `.github/workflows/inf-dev_infra.yaml` | `inf-dev_infra` |
+
+### Step 3: Apply Filters
+
+If `--domain` provided: keep only runs where the workflow name contains the domain string.
+If `--env` provided: keep only runs where the workflow name contains the env string.
+
+Both filters use substring matching for simplicity.
+
+### Step 4: Present Results
+
+Deduplicate: if the same workflow name appears multiple times (multiple batches), show only the most recent run.
+
+Use `AskUserQuestion` to show matching workflows. Each option:
+
+- **Label**: workflow name (e.g., `fes-streaming-dev`)
+- **Description**: `Run #<id> | Created: <created>`
+
+If no matches: report clearly, including which filters were applied.
+If one match: still present for confirmation.
+AskUserQuestion has a max of 4 options. If more than 4 matches, show the 4 most recent and note how many total were found.
+
+### Step 5: Open in Browser
+
+Run: `open https://github.com/fanatics-gaming/fanapp-terraform/actions/runs/<id>`

--- a/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: end-of-day
+description: This skill should be used when the user asks to "end of day", "EOD", "run end of day", "wrap up the day", "end of day routine", or runs "/end-of-day".
+version: 0.1.0
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent, TaskStop]
+---
+
+# End-of-Day Skill
+
+Run the full end-of-day capture pipeline: pull the day's meetings, extract Slack learnings (FES support to Confluence, support + internal channels to `raw/`), review the day's meeting action items into Todoist, then compile everything into the wiki.
+
+## Purpose
+
+Provide a single command that runs the complete daily wrap-up workflow with interactive gates at every step. Chains together meeting ingestion, three Slack-learning extractions, an interactive review of the day's meeting action items, and the full compile pipeline so the user doesn't have to remember to run each one manually at end of day.
+
+## When to Use
+
+Invoke this skill when:
+
+- User explicitly runs `/end-of-day`
+- User mentions "end of day", "EOD", "wrap up the day", "end of day routine"
+- User wants to capture the day's meetings + Slack activity and roll it into the wiki in one pass
+
+## When NOT to Use
+
+- If the user only wants to pull meetings: use `/lyt-assistant:meeting-ingest`
+- If the user only wants FES support learnings to Confluence: use `/fes-support-learnings:fes-support-learnings`
+- If the user only wants the support channel into `raw/`: use `/lyt-assistant:support-learnings`
+- If the user only wants the internal channel into `raw/`: use `/lyt-assistant:internal-channel-learnings`
+- If the user only wants to review meeting action items into Todoist: use `/lyt-assistant:meeting-action-items`
+- If the user only wants to compile already-collected sources: use `/lyt-assistant:compile`
+
+## Pipeline Overview
+
+```
+Step 1: Meetings (background)     ──┐  Pull Zoom transcripts into meetings/<date>/
+                                    │  (meeting-ingest, background subagent)
+                                    │
+Step 2: FES Support (background)  ──┤  Extract #fes-platform-support threads to Confluence
+                                    │  (fes-support-learnings:fes-support-learnings,
+                                    │   background subagent, non-interactive)
+                                    │
+Step 3: Support                     │  Extract support channel threads into raw/support_learnings/
+                                    │  (support-learnings, interactive)
+                                    │
+Step 4: Internal                    │  Extract #fes-platform-internal threads into raw/internal_learnings/
+                                    │  (internal-channel-learnings, interactive)
+                                    │
+Step 4.5: Join ─────────────────────┘  Wait for Steps 1 and 2 background subagents
+                                        to finish before running the remaining steps.
+
+Step 5: Meeting Action Items          Interactive review of the day's meeting action
+                                      items; creates Todoist tasks in the Work project
+                                      (meeting-action-items — consumes Step 1 output)
+
+Step 6: Compile                       Ingest raw/ into wiki/ + validate + discover links
+                                      (compile workflow — consumes Steps 3 & 4 output)
+
+Step 7: Report                        Summary of full pipeline run, appended to wiki/_log.md
+```
+
+Why this shape:
+
+- **Step 1 in parallel:** `meeting-ingest` writes to `meetings/` (not `raw/`), uses Zoom MCP (not Slack), and nothing downstream within Steps 2–4 reads its output. Fully independent, runs as a background subagent and overlaps with everything else.
+- **Step 2 in parallel:** `fes-support-learnings` reads `#fes-platform-support` and publishes to Confluence — the *same channel* Step 3 (`support-learnings`) reads. Because the user will already be reviewing those threads interactively in Step 3, Step 2 can run unattended in the background — any classification it would otherwise prompt on will get a second look during Step 3's review. Confluence output is reviewable post-hoc.
+- **Steps 3 and 4 sequential:** these two retain interactive per-thread review (classify / resolve / dismiss). They share the user's attention, so they run one at a time.
+- **Step 5 after the join:** `meeting-action-items` reads from `meetings/`, which Step 1 populates. Placing it after the join guarantees Step 1's background subagent has finished without pulling Step 1 foreground and killing the parallelism with Steps 2–4.
+- **Step 6 after Step 5:** `compile` reads from `raw/`, so it must run after Steps 3 and 4. It does not strictly depend on Steps 1, 2, or 5, but running it after the interactive steps keeps all user-attention work upstream of the final report.
+
+## Prerequisites
+
+Each sub-skill has its own requirements:
+
+- **Zoom MCP** (`claude.ai Zoom for Claude`) — for Step 1
+- **Slack MCP** (`claude.ai Slack`) — for Steps 2, 3, 4
+- **Atlassian MCP** — for Step 2 (publishes to Confluence)
+- **Todoist CLI (`td`) authenticated** — for Step 5 (creates Todoist tasks)
+
+Don't pre-flight-check all of these. Let each step fail naturally if its MCP or CLI is unauthed — the sub-skill itself reports the auth gap clearly. The failure-handling flow below covers that case.
+
+## Process Flow
+
+For each step: announce it, invoke the sub-skill, capture a one-line status (`ok` / `nothing-to-do` / `skipped` / `failed`) plus a short artifact summary for the final report. On failure, prompt the user — do not silently halt or barrel past.
+
+### Step 1: Meeting Ingest (background subagent)
+
+Dispatch meeting-ingest as a background subagent so it runs in parallel with Steps 2–4. Use the `Agent` tool with `subagent_type: general-purpose` (no specialized agent is needed — the work is "run this skill end-to-end and report a summary").
+
+Agent prompt template:
+
+> Run the `lyt-assistant:meeting-ingest` skill end-to-end with no arguments. It pulls the past 5 days of Zoom transcripts into `~/Documents/Work/meetings/<date-slug>/`, skipping meetings that already have folders. The Zoom MCP (`mcp__claude_ai_Zoom_for_Claude__*`) must be authenticated — if it isn't, stop and report that, do not try to authenticate. When the skill finishes, report a single block: number of meetings ingested, list of new folder paths, and any meetings skipped because they already existed. Under 150 words.
+
+Set `run_in_background: true` so the orchestrator does not block on this. Note the agent ID so it can be joined later (at Step 4.5).
+
+Do NOT poll or sleep waiting on it — the runtime notifies on completion. Proceed straight to Step 2.
+
+Track (recorded at the join in Step 4.5): meetings ingested, meetings skipped.
+
+Record status as one of:
+
+- `ok` — N new meetings ingested
+- `nothing-to-do` — all meetings already ingested
+- `failed` — see failure-handling below
+
+### Step 2: FES Support Learnings → Confluence (background subagent)
+
+Dispatch fes-support-learnings as a second background subagent so it runs in parallel with meeting-ingest and Steps 3–4. It lives in the `fes-support-learnings` plugin (separate from `lyt-assistant`) — use the fully-qualified skill name.
+
+Agent prompt template:
+
+> Run the `fes-support-learnings:fes-support-learnings` skill end-to-end with no arguments. It extracts threads from `#fes-platform-support` (default 7-day lookback) and publishes domain-grouped pages to Confluence. The Slack MCP and Atlassian MCP must both be authenticated — if either is missing, stop and report that, do not try to authenticate. **Run non-interactively**: for any per-thread classification or resolution prompt, pick the most reasonable default and continue; do not block waiting for user input. The user is independently reviewing the same channel's threads in the interactive `support-learnings` step running in the foreground, so anything ambiguous will get a second look there. When the skill finishes, report a single block: new threads processed, unresolved threads re-evaluated, Confluence page URL(s) created or updated, and any prompts you auto-defaulted (so the user can spot-check them). Under 200 words.
+
+Set `run_in_background: true`. Note the agent ID for the Step 4.5 join.
+
+Do NOT poll or sleep. Proceed straight to Step 3.
+
+Track (recorded at the join): new threads processed, unresolved threads re-evaluated, Confluence page URL(s), list of auto-defaulted prompts.
+
+### Step 3: Support Learnings → `raw/`
+
+Invoke the (lyt-assistant) support-learnings skill, which writes to `~/Documents/Work/raw/support_learnings/`:
+
+```
+Skill: lyt-assistant:support-learnings
+Args: (none — process new threads since last run)
+```
+
+Track: number of new threads processed, output file path(s). These files become inputs for Step 6 (Compile).
+
+### Step 4: Internal Channel Learnings → `raw/`
+
+Invoke the internal-channel-learnings skill, which writes to `~/Documents/Work/raw/internal_learnings/`:
+
+```
+Skill: lyt-assistant:internal-channel-learnings
+Args: (none — process new threads since last run)
+```
+
+Track: number of new threads processed and their categories (decision / incident / knowledge / process-change / discussion), output file path(s). These files also feed Step 6 (Compile).
+
+### Step 4.5: Join — Wait for Background Subagents
+
+Before starting compile, ensure both Step 1 (meeting-ingest) and Step 2 (fes-support-learnings) background subagents have completed.
+
+- For each subagent: if the runtime has already delivered its completion notification, read its result block and record status + summary. If still running, wait for the completion notification — do NOT poll, sleep, or proactively check; the runtime notifies on completion.
+- The two foreground interactive steps (3 and 4) almost always take longer than the background subagents, so this wait is usually instant.
+- **Missing-notification fallback:** if a subagent has been running noticeably longer than expected and no completion notification has arrived (e.g. the runtime dropped the event, or the subagent crashed silently without reporting), surface this to the user, treat the subagent as failed, and apply the continue / retry / halt prompt below. Do not hang Step 4.5 indefinitely.
+- If either subagent reported a failure (e.g. Zoom MCP unauthed, Atlassian MCP unauthed), apply the same continue / retry / halt prompt described in Error Handling below. Treat each subagent's failure independently — one can succeed while the other fails.
+- For fes-support-learnings specifically: surface its list of auto-defaulted prompts to the user as part of the join. They are not errors, but the user may want to spot-check them.
+
+### Step 5: Meeting Action Items
+
+Invoke the meeting-action-items skill with no arguments (its default lookback is "since last run, fallback 2 days"). Step 1 has finished by this point, so any meetings ingested in Step 1 are now visible to this step.
+
+```
+Skill: lyt-assistant:meeting-action-items
+Args: (none)
+```
+
+**Must run interactively in the foreground session.** Invoke via the `Skill` tool in the main conversation — do NOT dispatch via `Agent` (background or foreground) and do NOT instruct it to "run non-interactively" like Step 2. The skill drives a per-item prompt loop that requires the user at the keyboard: `[t]` make todo / `[d]` dismiss / `[s]` skip / `[q]` quit, plus a bulk-triage shortcut. A subagent has no way to surface those prompts to the user, so dispatching it that way would either hang, auto-default every item, or silently dismiss work that should have become a todo.
+
+Track for the run: number of items reviewed, number of new todos created, number dismissed, number skipped.
+
+Record status:
+
+- `ok` — items reviewed and any todos created
+- `nothing-new` — no unhandled action items in the lookback window
+- `quit-early` — user quit mid-loop; still proceed to Step 6 with partial progress
+- `failed` — see Error Handling
+
+### Step 6: Compile
+
+Invoke the compile skill, which itself chains ingest → validate → discover-links:
+
+```
+Skill: lyt-assistant:compile
+Args: (none)
+```
+
+Track: articles created, articles updated, stubs created, validation fixes applied, new connections added. The compile skill handles its own logging to `wiki/_log.md`.
+
+### Step 7: Final Report
+
+Summarize the full end-of-day run in one block:
+
+```
+End-of-Day Complete
+
+  Step 1 — Meetings (parallel):
+    New meetings: 3
+    Skipped (already present): 2
+
+  Step 2 — FES Support → Confluence (parallel):
+    New threads: 4
+    Unresolved revisited: 2
+    Confluence page: https://.../2026-05-12-learnings
+    Auto-defaulted prompts: 1 (thread T1234 classified as "knowledge" by default)
+
+  Step 3 — Support → raw/:
+    New threads: 4
+    Files written: 1 (raw/support_learnings/2026-05-12.md)
+
+  Step 4 — Internal → raw/:
+    New threads: 6 (2 decision, 1 incident, 3 knowledge)
+    Files written: 1 (raw/internal_learnings/2026-05-12.md)
+
+  Step 5 — Meeting Action Items:
+    Items reviewed: 5
+    Todos created: 3
+    Dismissed: 1
+    Skipped: 1
+
+  Step 6 — Compile:
+    Articles created: 4
+    Articles updated: 2
+    Stubs created: 1
+    Validation fixes: 1
+    New connections: 7
+
+  Activity logged to: wiki/_log.md
+```
+
+Then append an end-of-day block to `wiki/_log.md`:
+
+```markdown
+## [2026-05-12] end-of-day | Daily Pipeline
+
+- Meetings ingested: 3
+- FES support threads → Confluence: 4 new, 2 revisited
+- Support threads → raw/: 4
+- Internal threads → raw/: 6 (2 decision, 1 incident, 3 knowledge)
+- Meeting action items: 5 reviewed, 3 created, 1 dismissed, 1 skipped
+- Compile: 4 created, 2 updated, 7 new connections
+- Step failures: none
+```
+
+If any steps failed or were skipped, list them in a `- Step failures:` line.
+
+## Error Handling
+
+### A Sub-Skill Reports Its MCP Isn't Authed
+
+The sub-skill will tell the user to authenticate. Don't try to authenticate on its behalf. Surface the message and prompt:
+
+```
+Step 2 (FES Support) couldn't run: Atlassian MCP not authenticated.
+
+The sub-skill suggests running `/plugin` and authenticating Atlassian, then retrying.
+
+  [c] Continue — skip this step and move to Step 3
+  [r] Retry — user authenticates now, then retry Step 2
+  [h] Halt — stop the pipeline here
+
+Choice?
+```
+
+Default behavior is to ask, not assume. One auth glitch should not abort the whole run.
+
+### A Sub-Skill Errors Mid-Run
+
+If a sub-skill starts but errors part-way through (e.g. Slack API rate limit, a thread the skill can't classify, a write failure), surface the error and prompt the same continue / retry / halt choice. Capture whatever partial output the sub-skill produced in the per-step status.
+
+### A Sub-Skill Has Nothing to Do
+
+This is not an error. Mark the step `nothing-to-do` and continue without prompting.
+
+### `meeting-action-items` Quits Early
+
+If the user hits `[q]` partway through Step 5's per-item loop, treat that as `ok` (partial-progress), report how far the run got, and continue to Step 6 — compile and the final report are still useful.
+
+### Pipeline Interruption
+
+If the user cancels mid-pipeline, also stop any background subagents (Steps 1 and 2) that are still running — use `TaskStop` on each agent ID. Then report what was completed and what remains:
+
+```
+End-of-Day interrupted after Step 3 (Support Learnings).
+
+Completed:
+  - Step 1: Meetings — 3 new (background subagent finished before interrupt)
+  - Step 2: FES Support — 4 new threads → Confluence (background subagent finished before interrupt)
+  - Step 3: Support → raw/ — 4 new threads
+
+Not yet run:
+  - Step 4: Internal Channel — run /lyt-assistant:internal-channel-learnings
+  - Step 5: Meeting Action Items — run /lyt-assistant:meeting-action-items
+  - Step 6: Compile — run /lyt-assistant:compile (will pick up Step 3 output plus Step 4 if you run it)
+```
+
+If a background subagent was still running when the interrupt happened, mark it `cancelled` instead of `ok` and note what its last reported progress was, if available.
+
+## Related Skills
+
+- **/lyt-assistant:meeting-ingest** — Pull Zoom transcripts (Step 1)
+- **/fes-support-learnings:fes-support-learnings** — FES support → Confluence (Step 2; lives in the `fes-support-learnings` plugin)
+- **/lyt-assistant:support-learnings** — Support channel → `raw/support_learnings/` (Step 3)
+- **/lyt-assistant:internal-channel-learnings** — Internal channel → `raw/internal_learnings/` (Step 4)
+- **/lyt-assistant:meeting-action-items** — Interactive review of meeting action items into Todoist (Step 5)
+- **/lyt-assistant:compile** — Full compilation pipeline (Step 6; itself chains `/lyt-assistant:ingest` → `/lyt-assistant:lint` → `/lyt-assistant:discover-links`)
+- **/start-of-day** — Morning counterpart; lists today + overdue Todoist tasks with an inline edit loop (user-private skill at `~/.claude/skills/start-of-day/`)
+
+## Summary
+
+The end-of-day skill runs the full daily wrap-up: pull the day's Zoom meetings, extract three Slack channels' worth of learnings (FES support to Confluence, support and internal channels to `raw/`), review the day's meeting action items into Todoist, then compile `raw/` into the wiki. It chains six skills in order so the day's commitments and Slack-derived notes get captured and into the wiki the same day rather than waiting until the next compile. Use `/end-of-day` as the single command to wrap up the workday.

--- a/stow-packages/claude/.claude/skills/find-docs/SKILL.md
+++ b/stow-packages/claude/.claude/skills/find-docs/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: find-docs
+description: >-
+  Retrieves authoritative, up-to-date technical documentation, API references,
+  configuration details, and code examples for any developer technology.
+
+  Use this skill whenever answering technical questions or writing code that
+  interacts with external technologies. This includes libraries, frameworks,
+  programming languages, SDKs, APIs, CLI tools, cloud services, infrastructure
+  tools, and developer platforms.
+
+  Common scenarios:
+  - looking up API endpoints, classes, functions, or method parameters
+  - checking configuration options or CLI commands
+  - answering "how do I" technical questions
+  - generating code that uses a specific library or service
+  - debugging issues related to frameworks, SDKs, or APIs
+  - retrieving setup instructions, examples, or migration guides
+  - verifying version-specific behavior or breaking changes
+
+  Prefer this skill whenever documentation accuracy matters or when model
+  knowledge may be outdated.
+---
+
+# Documentation Lookup
+
+Retrieve current documentation and code examples for any library using the Context7 CLI.
+
+Make sure the CLI is up to date before running commands:
+
+```bash
+npm install -g ctx7@latest
+```
+
+Or run directly without installing:
+
+```bash
+npx ctx7@latest <command>
+```
+
+## Workflow
+
+Two-step process: resolve the library name to an ID, then query docs with that ID.
+
+```bash
+# Step 1: Resolve library ID
+ctx7 library <name> <query>
+
+# Step 2: Query documentation
+ctx7 docs <libraryId> <query>
+```
+
+You MUST call `ctx7 library` first to obtain a valid library ID UNLESS the user explicitly provides a library ID in the format `/org/project` or `/org/project/version`.
+
+IMPORTANT: Do not run these commands more than 3 times per question. If you cannot find what you need after 3 attempts, use the best result you have.
+
+## Step 1: Resolve a Library
+
+Resolves a package/product name to a Context7-compatible library ID and returns matching libraries.
+
+```bash
+ctx7 library react "How to clean up useEffect with async operations"
+ctx7 library nextjs "How to set up app router with middleware"
+ctx7 library prisma "How to define one-to-many relations with cascade delete"
+```
+
+Always pass a `query` argument — it is required and directly affects result ranking. Use the user's intent to form the query, which helps disambiguate when multiple libraries share a similar name. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
+
+### Result fields
+
+Each result includes:
+
+- **Library ID** — Context7-compatible identifier (format: `/org/project`)
+- **Name** — Library or package name
+- **Description** — Short summary
+- **Code Snippets** — Number of available code examples
+- **Source Reputation** — Authority indicator (High, Medium, Low, or Unknown)
+- **Benchmark Score** — Quality indicator (100 is the highest score)
+- **Versions** — List of versions if available. Use one of those versions if the user provides a version in their query. The format is `/org/project/version`.
+
+### Selection process
+
+1. Analyze the query to understand what library/package the user is looking for
+2. Select the most relevant match based on:
+   - Name similarity to the query (exact matches prioritized)
+   - Description relevance to the query's intent
+   - Documentation coverage (prioritize libraries with higher Code Snippet counts)
+   - Source reputation (consider libraries with High or Medium reputation more authoritative)
+   - Benchmark score (higher is better, 100 is the maximum)
+3. If multiple good matches exist, acknowledge this but proceed with the most relevant one
+4. If no good matches exist, clearly state this and suggest query refinements
+5. For ambiguous queries, request clarification before proceeding with a best-guess match
+
+### Version-specific IDs
+
+If the user mentions a specific version, use a version-specific library ID:
+
+```bash
+# General (latest indexed)
+ctx7 docs /vercel/next.js "How to set up app router"
+
+# Version-specific
+ctx7 docs /vercel/next.js/v14.3.0-canary.87 "How to set up app router"
+```
+
+The available versions are listed in the `ctx7 library` output. Use the closest match to what the user specified.
+
+## Step 2: Query Documentation
+
+Retrieves up-to-date documentation and code examples for the resolved library.
+
+```bash
+ctx7 docs /facebook/react "How to clean up useEffect with async operations"
+ctx7 docs /vercel/next.js "How to add authentication middleware to app router"
+ctx7 docs /prisma/prisma "How to define one-to-many relations with cascade delete"
+```
+
+### Writing good queries
+
+The query directly affects the quality of results. Be specific and include relevant details. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
+
+| Quality | Example |
+|---------|---------|
+| Good | `"How to set up authentication with JWT in Express.js"` |
+| Good | `"React useEffect cleanup function with async operations"` |
+| Bad | `"auth"` |
+| Bad | `"hooks"` |
+
+Use the user's full question as the query when possible, vague one-word queries return generic results.
+
+The output contains two types of content: **code snippets** (titled, with language-tagged blocks) and **info snippets** (prose explanations with breadcrumb context).
+
+## Authentication
+
+Works without authentication. For higher rate limits:
+
+```bash
+# Option A: environment variable
+export CONTEXT7_API_KEY=your_key
+
+# Option B: OAuth login
+ctx7 login
+```
+
+## Error Handling
+
+If a command fails with a quota error ("Monthly quota reached" or "quota exceeded"):
+1. Inform the user their Context7 quota is exhausted
+2. Suggest they authenticate for higher limits: `ctx7 login`
+3. If they cannot or choose not to authenticate, answer from training knowledge and clearly note it may be outdated
+
+Do not silently fall back to training data — always tell the user why Context7 was not used.
+
+## Common Mistakes
+
+- Library IDs require a `/` prefix — `/facebook/react` not `facebook/react`
+- Always run `ctx7 library` first — `ctx7 docs react "hooks"` will fail without a valid ID
+- Use descriptive queries, not single words — `"React useEffect cleanup function"` not `"hooks"`
+- Do not include sensitive information (API keys, passwords, credentials) in queries

--- a/stow-packages/claude/.claude/skills/finish-work/SKILL.md
+++ b/stow-packages/claude/.claude/skills/finish-work/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: finish-work
+description: Close out a JIRA ticket inferred from the current branch — transition based on PR state, capture learnings into project documents, and optionally clean up the worktree.
+arguments: []
+---
+
+# Finish Work Workflow
+
+You are closing out the work tied to the current git branch. This is the bookend to `/start-ticket`: it transitions the JIRA ticket, captures learnings into the right project documents, and optionally cleans up the worktree.
+
+Follow these steps in order. Each step has explicit branching logic — do not skip or reorder them.
+
+## Step 1: Detect the ticket key from the branch
+
+- Run `git rev-parse --abbrev-ref HEAD`.
+- Extract the ticket key with regex `^[A-Z]+-\d+`. This handles both `FANDEVX-2926/foo` and `FANDEVX-2926-foo` formats.
+- If no match, stop with the message: `Branch '<name>' does not start with a JIRA ticket key. Aborting.`
+
+## Step 2: Confirm GitHub identity
+
+- Run `gh auth status`.
+- If the active account is not `ian-at-fes`, instruct the user to switch (`gh auth switch -u ian-at-fes`) before continuing. Do not auto-switch — the user's CLAUDE.md mandates explicit identity management.
+
+## Step 3: Fetch ticket and PR state in parallel
+
+- JIRA: use the Atlassian MCP server (`getJiraIssue` and `getTransitionsForJiraIssue`) to fetch the ticket summary, current status, and available transitions.
+- PR: `gh pr view --json state,merged,url,headRefName` on the current branch. If `gh pr view` exits non-zero, treat it as "no PR".
+- Display a short summary to the user: ticket key, summary, current JIRA status, PR state (merged / open / closed-unmerged / none) with URL when present.
+
+## Step 4: Determine and execute the JIRA transition
+
+Smart default based on PR state:
+
+| PR state           | Target transition |
+|--------------------|-------------------|
+| merged             | Done              |
+| open               | In Review         |
+| closed (unmerged)  | ask user          |
+| no PR              | ask user          |
+
+- Show the user the chosen target transition (or the prompt for "closed-unmerged" / "no PR") alongside the available transitions list from JIRA. Confirm before executing.
+- Execute the transition via the Atlassian MCP server (`transitionJiraIssue`).
+- If the transition fails (e.g., required field missing), surface the error and prompt the user — do not silently swallow.
+
+## Step 5: Find the project folder
+
+- Run `grep -l "<TICKET-KEY>" ~/Documents/Work/projects/*/log.md` (case-sensitive, exact ticket key).
+- Exactly 1 match: use that project.
+- 0 matches or 2+ matches: present the user with the full list of subdirectories under `~/Documents/Work/projects/` plus a "none — skip project updates" option, and let them pick.
+
+If the user picks "none", skip Steps 6 and 7 and continue to Step 8.
+
+## Step 6: Gather learnings sources in parallel
+
+- **Conversation context**: synthesize from the current Claude session — what was tried, what failed, what worked, decisions made, dead ends.
+- **Git log**: determine the base branch (`main` for most repos; use `git symbolic-ref refs/remotes/origin/HEAD` if uncertain), then run `git log <base-branch>..HEAD --pretty=format:'%h %s%n%b'` to capture concrete shipped commits.
+- If the session is fresh and has no conversation context (e.g., running `/finish-work` cold the next morning), fall back to git-log-only and tell the user the log entry will be sparse.
+
+## Step 7: Draft and apply project document updates
+
+For each of the following documents, draft an addition, show it as a diff, and apply only on user approval. Use a separate approval prompt for each — never bundle them.
+
+### `log.md` — always
+
+Append one dated entry per finish, using this structure:
+
+```
+## YYYY-MM-DD — <ticket-key>: <ticket summary>
+
+**Outcome:** <merged / in-review / closed-unmerged / etc.>
+
+**What shipped:**
+- <bullets from git log>
+
+**Learnings:**
+- <bullets from conversation context>
+```
+
+### `decisions.md` — only if applicable
+
+Only update if an architectural choice surfaced during the session. Append a dated entry with: decision, alternatives considered, rationale.
+
+### `todos-and-followups.md` — only if applicable
+
+Only update if new follow-up items emerged. Append as a bulleted list under a dated heading.
+
+### Missing files
+
+If a target doc doesn't exist in the project folder (e.g., no `decisions.md`), create it with a minimal markdown header (`# Decisions`, `# Todos and Follow-ups`) before appending.
+
+## Step 8: Worktree cleanup
+
+- Detect worktree state: parse `git worktree list --porcelain` and compare to the current working directory.
+- If the current directory is the main checkout (not a worktree): skip silently.
+- If on a worktree:
+  1. **Check for uncommitted changes**: run `git status --porcelain`. If non-empty, warn the user and ask whether to abort cleanup or discard changes.
+  2. **Decide based on PR state**:
+     - **PR merged OR closed-unmerged**: prompt `Clean up worktree '<path>' and delete branch '<name>'? [y/n]`. On `y`, change directory out of the worktree to the main checkout path (from `git worktree list`), then run `git worktree remove <path>` and `git branch -D <name>`. Prefer the `ExitWorktree` tool if available.
+     - **PR still open**: skip cleanup. Tell the user the worktree was left in place because the PR is still open.
+
+## Step 9: Final summary
+
+Print a recap:
+
+- **Ticket**: transitioned `<from>` → `<to>` (with JIRA URL)
+- **Project updates**: list of files modified, or "skipped"
+- **Worktree**: removed / left in place / not applicable
+
+## What this skill does NOT do
+
+- Does not push code, open PRs, or merge anything — use `commit-commands:commit-push-pr`.
+- Does not run tests or verify the work — use `superpowers:verification-before-completion`.
+- Does not bulk-clean other worktrees — use `commit-commands:clean_gone`.

--- a/stow-packages/claude/.claude/skills/one-pager/SKILL.md
+++ b/stow-packages/claude/.claude/skills/one-pager/SKILL.md
@@ -1,0 +1,474 @@
+---
+name: one-pager
+description: This skill should be used when the user asks to "write a one-pager", "draft a one-pager", "make a one-pager", or "create a TechOps one-pager". Drafts a persuasion-focused one-page proposal in raw/one-pagers/ following the TechOps 1 Pager Template (Confluence page 1898676290, FAN space) — header table (Published / Authors / Jira Tickets / Status) and sections What / Why / Other Considerations / Additional Reading. Runs three parallel agent personas (TPM, Lead Platform Engineer, Engineering Manager) for feedback, iterates with the user until approved, then publishes as a draft child of the TechOps 1-Pagers page in Confluence (parent 1164869728, FAN space) and gates the final publish on user confirmation.
+version: 0.2.0
+argument-hint: "[topic or short pitch]"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Agent, mcp__plugin_fbg-core_atlassian__getAccessibleAtlassianResources, mcp__plugin_fbg-core_atlassian__getConfluencePage, mcp__plugin_fbg-core_atlassian__createConfluencePage, mcp__plugin_fbg-core_atlassian__updateConfluencePage]
+---
+
+# One-Pager Skill
+
+Draft, review, and publish a TechOps one-pager end-to-end. The skill writes a draft to `raw/one-pagers/`, runs three parallel agent reviewers (TPM, Lead Platform Engineer, Engineering Manager), iterates with the user, then publishes to Confluence as a draft under `TechOps 1-Pagers` (parent page `1164869728`, space `FAN`) and gates the final publish on the user's confirmation in Confluence.
+
+## When to Use
+
+Invoke this skill when:
+
+- User runs `/lyt-assistant:one-pager` (with or without a topic argument)
+- User says "write a one-pager", "draft a one-pager", "make a one-pager", "create a TechOps one-pager", or any variation
+- User wants to socialize a proposal with stakeholders before committing to an RFC
+
+## Format Reference
+
+The canonical section structure is the **TechOps 1 Pager Template** in Confluence (page id `1898676290`, FAN space). This skill mirrors that template exactly so drafts publish cleanly under the same parent and read consistently with sibling one-pagers.
+
+Persuasion principles come from the user's wiki at `~/Documents/Work/wiki/concepts/one-pager-and-rfc.md`:
+
+- **Audience:** anyone who decides whether the thing happens (managers, VPs, peer leads). Usually *not* engineers who'd build it.
+- **Goal:** agreement on the *outcome* and the *why*, not on the design.
+- **Length:** the wiki says only *"One page. Anything longer is no longer a one-pager"* and flags *"one-pager that's actually three pages"* as the top anti-pattern. This skill operationalizes that with a soft target of 400–600 words and a hard trim above 700 — those numbers are this skill's calibration, not wiki-quoted.
+- **Style:** persuasive, not exhaustive. Skip implementation details — they invite premature objections about *how* before *whether*.
+
+Header metadata (template table at the top of every page):
+
+| Field | Notes |
+|-------|-------|
+| **Published** | Date the page goes live (or current date for drafts). |
+| **Authors** | One or more author names. |
+| **Jira Tickets** | Optional related tickets. |
+| **Status** | One of `Draft`, `Defining`, `Building`, `Completed`. |
+
+Required sections (every one-pager):
+
+1. **What** *(required)* — the outcome you hope to accomplish. Describe the *outcome*, not the technical approach. Avoid prescriptive tool selection.
+2. **Why** *(required)* — why this needs to be considered and prioritized. Not the same as "what".
+
+Optional sections (include when they add signal):
+
+1. **Other Considerations** *(optional)* — security, compliance, developer experience, operational load, anything else that should be weighed.
+2. **Additional Reading** *(optional)* — context links (RFCs, dashboards, prior one-pagers, vendor docs).
+
+## Paths
+
+All file paths are relative to the **vault root** (`~/Documents/Work/`):
+
+- Drafts: `raw/one-pagers/.draft-<slug>.md`
+- Final: `raw/one-pagers/<slug>.md`
+
+The dot-prefix on drafts mirrors the `research` skill's convention and hides them from any future `/compile`-style scanners.
+
+## Workflow
+
+### Step 1 — Gather input
+
+If the user passed a topic on the command line (e.g. `/lyt-assistant:one-pager adopt Karpenter org-wide`), use it as the working title. Otherwise ask:
+
+```
+What's the working title for this one-pager?
+```
+
+Then collect the remaining inputs via plain conversational prompts (one at a time, accept multi-line answers). Do **not** use `AskUserQuestion` here — the answers are free text, not menu choices.
+
+| Field | Prompt |
+|-------|--------|
+| Audience | Who decides whether this happens? (e.g. "VP Eng + peer team leads") |
+| Authors | Author name(s) for the header table (defaults to `Ian Bartholomew` if blank). |
+| Jira tickets | Optional. Related tickets (comma-separated keys, e.g. `FANDEVX-2444, FESFEAT-428`). Leave blank to omit. |
+| What | One paragraph: the *outcome* you hope to accomplish. Describe the outcome, not the technical approach. Avoid prescribing tools. |
+| Why | One paragraph: why this needs to be considered and prioritized. Not the same as "what". |
+| Other considerations | Optional. Security, compliance, developer experience, operational load, edge cases. Leave blank to omit. |
+| Additional reading | Optional. Context links (RFCs, dashboards, prior one-pagers, vendor docs). Leave blank to omit. |
+
+If the user gives a very short answer for any field, accept it — the persona reviewers in Step 4 will flag thinness.
+
+### Step 2 — Pre-flight checks
+
+```bash
+VAULT_ROOT="$HOME/Documents/Work"
+ONE_PAGERS_DIR="$VAULT_ROOT/raw/one-pagers"
+mkdir -p "$ONE_PAGERS_DIR"
+
+# Derive kebab-case slug from title
+SLUG=$(printf '%s' "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+
+DRAFT_PATH="$ONE_PAGERS_DIR/.draft-$SLUG.md"
+FINAL_PATH="$ONE_PAGERS_DIR/$SLUG.md"
+```
+
+If either `$DRAFT_PATH` or `$FINAL_PATH` already exists, ask via `AskUserQuestion`:
+
+- **Resume** — re-open the existing draft and skip ahead to Step 4
+- **Overwrite** — discard the existing file and write fresh
+- **Rename** — prompt for a new title and recompute the slug
+- **Cancel** — exit
+
+### Step 3 — Write the draft
+
+Write `$DRAFT_PATH` with this template. The header table mirrors the canonical TechOps 1 Pager Template (Confluence page `1898676290`) so the published page reads identically to its siblings. Omit any optional section the user left blank — do not include a heading with placeholder filler.
+
+```markdown
+---
+title: <Title>
+audience: <Audience>
+authors: <Authors>
+date: <YYYY-MM-DD>
+status: draft
+jira_tickets: <comma-separated keys or empty>
+confluence_parent_id: "1164869728"
+confluence_template_id: "1898676290"
+confluence_space: FAN
+confluence_page_id: null
+confluence_url: null
+---
+
+# <Title>
+
+| **Published** | <YYYY-MM-DD> |
+| --- | --- |
+| **Authors** | <Authors> |
+| **Jira Tickets** | <ticket keys or `—`> |
+| **Status** | Draft |
+
+## What
+
+<One paragraph describing the *outcome* you hope to accomplish. Do not go deep on technical approach; do not prescribe tools.>
+
+## Why
+
+<One paragraph explaining why this needs to be considered and prioritized. Different from "what".>
+
+## Other Considerations
+
+<Optional. Security, compliance, developer experience, operational load, edge cases.>
+
+## Additional Reading
+
+<Optional. Context links (RFCs, dashboards, prior one-pagers, vendor docs).>
+```
+
+**Status field semantics.** The header `Status` row tracks the *lifecycle* of the proposal in Confluence (`Draft` → `Defining` → `Building` → `Completed`), per the TechOps template's enum. Drafts always start at `Draft`. The frontmatter `status` field tracks the *local file* lifecycle (`draft` → `published`) and is set automatically by this skill — do not conflate the two.
+
+**Length guard.** After writing, count words in the body (everything below the closing `---` of frontmatter):
+
+```bash
+WORDS=$(awk '/^---$/{c++; next} c>=2' "$DRAFT_PATH" | wc -w | tr -d ' ')
+```
+
+- ≤ 600 words: ideal.
+- 601–700: acceptable, note in the reviewer dispatch.
+- > 700: trim before Step 4. The wiki explicitly calls out *"one-pager that's actually three pages"* as the top anti-pattern.
+
+### Step 4 — Parallel persona review
+
+Dispatch **three `Agent` calls in a single message** (one tool-use block with three `Agent` calls). Each agent gets `Read`-only access — the main loop holds the pen.
+
+Use `subagent_type: "general-purpose"` for all three. Pass the absolute draft path so each agent can `Read` it directly.
+
+**Shared response contract** (include in every persona prompt):
+
+```
+Return ONLY this format:
+
+  Top issues:
+    1. <issue>
+    2. <issue>
+    3. <issue>
+
+  Missing or unclear:
+    - <item>
+    - <item>
+
+  Suggested edits:
+    - <section>: <concrete edit>
+    - <section>: <concrete edit>
+
+  Verdict: approve | revise
+
+Keep your response under 250 words. Do not write the one-pager yourself — only critique.
+```
+
+**Persona prompts** (substitute `<DRAFT_PATH>` with the absolute path):
+
+**TPM:**
+
+```
+You are a Technical Project Manager reviewing a one-pager at <DRAFT_PATH>.
+The page follows the TechOps 1 Pager Template: a header table (Published / Authors / Jira Tickets / Status), then **What**, **Why**, optionally **Other Considerations** and **Additional Reading**.
+
+Your concerns:
+- Is **What** a clear, bounded outcome — or does it drift into prescribing technical approach/tools (template explicitly bars this)?
+- Does **Why** make the prioritization case, or does it just restate **What**?
+- Are cross-team dependencies, sequencing, and timeline implications surfaced (in Why or Other Considerations)?
+- Is the Jira Tickets cell populated where applicable? Is Status appropriate (Draft for new proposals)?
+
+Read the file, then return the response format described below.
+
+[shared response contract]
+```
+
+**Lead Platform Engineer:**
+
+```
+You are a Lead Platform Engineer reviewing a one-pager at <DRAFT_PATH>.
+The page follows the TechOps 1 Pager Template: a header table (Published / Authors / Jira Tickets / Status), then **What**, **Why**, optionally **Other Considerations** and **Additional Reading**.
+
+Your concerns:
+- Is the outcome in **What** technically feasible without leaking into design? (Template explicitly discourages tool/approach prescription here.)
+- Is **Why** honest about the cost — or does it oversell the upside?
+- Are second-order effects (migration paths, operational load, security/compliance/DX, edge cases) captured in **Other Considerations**? If that section is missing entirely, is its absence justified?
+- Does the framing risk misleading non-engineers about real implementation cost?
+
+Read the file, then return the response format described below.
+
+[shared response contract]
+```
+
+**Engineering Manager:**
+
+```
+You are an Engineering Manager reviewing a one-pager at <DRAFT_PATH>.
+The page follows the TechOps 1 Pager Template: a header table (Published / Authors / Jira Tickets / Status), then **What**, **Why**, optionally **Other Considerations** and **Additional Reading**.
+
+Your concerns:
+- Does **Why** answer "why prioritize this now over what we're already doing"? Capacity/displacement implicit?
+- Is the outcome in **What** worth the prioritization cost it implies?
+- Will the named audience actually buy in, or is the framing off for them?
+- Are staffing or hiring assumptions hidden inside **Why** or **Other Considerations**?
+
+Read the file, then return the response format described below.
+
+[shared response contract]
+```
+
+### Step 5 — Incorporate reviewer feedback
+
+Merge the three reports. Group suggested edits by section. Deduplicate (multiple reviewers often flag the same thing).
+
+Apply edits to `$DRAFT_PATH` using `Edit`. Prefer surgical changes — don't rewrite passages the reviewers didn't flag.
+
+Show the user a compact digest before moving on:
+
+```
+Reviewer round 1:
+
+  TPM: revise (3 issues)
+  Lead Platform Engineer: revise (2 issues)
+  Engineering Manager: approve
+
+  Merged edits applied:
+    - What: stripped "by deploying Karpenter v0.34" — too prescriptive (TPM, Lead PE)
+    - Why: added Q3 cost-review forcing function (TPM, EM)
+    - Other Considerations: added "node-replacement churn during pilot" (Lead PE)
+    - Header: added FANDEVX-2448 to Jira Tickets row (TPM)
+
+  Word count: 487
+```
+
+### Step 6 — User review
+
+Print the draft path and a short diff-style summary of what changed. Then ask via `AskUserQuestion`:
+
+- **Approve** — proceed to Confluence publish
+- **Revise** — describe what you'd like changed (or edit the file directly, then say "re-review")
+- **Cancel** — leave the draft on disk and exit
+
+If the user picks **Revise**, accept either:
+
+- inline change instructions in their answer → apply via `Edit`
+- a signal that they edited the file themselves → read the file fresh
+
+Then loop to Step 7.
+
+### Step 7 — Re-review loop
+
+1. Re-run Step 4 (parallel persona review) on the modified draft.
+2. Incorporate feedback per Step 5.
+3. **Go to Step 6.** Always. There is no other exit from Step 7.
+
+**Termination:** the loop exits only when the user picks Approve or Cancel at Step 6.
+
+**Iteration counter:** track rounds. After **3 rounds**, prepend the Step 6 prompt with:
+
+```
+You've done 3 review rounds. Continuing is fine, but this is also a good place
+to ship and let the audience push back on real content rather than polish.
+```
+
+This is a nudge, not a hard cap.
+
+### Step 8 — Publish to Confluence as draft
+
+Once the user approves at Step 6:
+
+1. **Verify connectivity.** Call `mcp__plugin_fbg-core_atlassian__getConfluencePage` with `pageId: "1164869728"` to confirm the TechOps 1-Pagers parent exists and is reachable on the current auth. If 404 or auth fails, bail with a clear error and instructions to re-auth. Optionally call `getAccessibleAtlassianResources` first if you need to discover the FAN cloud id — but the subsequent create/update calls in this skill do not consume `cloudId` directly; the MCP plugin resolves the tenant from the authenticated session.
+
+2. **Inspect the `createConfluencePage` schema** (use `ToolSearch` with `query: "select:mcp__plugin_fbg-core_atlassian__createConfluencePage"` to load it if it isn't already in scope). Determine:
+   - Whether it accepts `spaceKey` or requires `spaceId` (the latter would need a lookup via `getConfluenceSpaces`).
+   - Whether `status: "draft"` is exposed.
+   - Whether `body` accepts markdown directly or requires storage format.
+
+3. **Pre-call confirmation gate.** If the schema does **not** expose `status: "draft"`, the page will be created as a live (current) page in a public space the moment the call fires. Before calling, ask via `AskUserQuestion`:
+
+   ```
+   The MCP tool does not support draft pages. Creating this one-pager will
+   publish it immediately as a live page under TechOps 1-Pagers in the FAN
+   space. The Step 9 "publish" gate will then be a no-op.
+
+   Continue and create as a live page?
+   [Continue / Cancel]
+   ```
+
+   If the user picks Cancel, exit the skill with the local draft preserved at `$DRAFT_PATH`. Do not create the page.
+
+   If `status: "draft"` is exposed, skip this prompt and proceed.
+
+4. **Create the page.** Call `mcp__plugin_fbg-core_atlassian__createConfluencePage` with:
+   - `spaceKey: "FAN"` (or `spaceId` from the lookup above)
+   - `parentId: "1164869728"`
+   - `title`: the one-pager title from frontmatter
+   - `body`: the markdown body (everything below the frontmatter's closing `---`). The template includes a header metadata table (Published / Authors / Jira Tickets / Status) — markdown tables render natively in Confluence, no conversion needed. There are no images or macros to preserve on a fresh create.
+   - `contentFormat: "markdown"`
+   - `status: "draft"` only if the schema accepted it in step 2.
+
+5. **Persist Confluence identity** — update the draft's frontmatter via `Edit`:
+   - `confluence_page_id`: the returned page id
+   - `confluence_url`: the returned `_links.webui` (or equivalent absolute URL)
+
+### Step 9 — User confirms the Confluence page
+
+Print the Confluence URL and ask via `AskUserQuestion`:
+
+- **Publish** — promote the page from draft → current
+- **Revise** — describe changes; apply to the local draft via `Edit`, then push to Confluence via `mcp__plugin_fbg-core_atlassian__updateConfluencePage` (keeping `status: "draft"` if supported), then loop back to this step
+- **Cancel** — leave the page as draft in Confluence and exit (state is preserved in the local file's frontmatter; a re-run can resume)
+
+**Reviewer personas do not re-run here.** Step 9 is a last-mile polish gate, not a content gate — the persona reviewers already approved at Step 6. If the user makes a substantive (non-cosmetic) change at this stage, mention this in the response: "I've updated the local draft and pushed to Confluence. The reviewer personas don't re-run at this stage — if you'd like another full review round, cancel and re-run the skill on the published draft."
+
+On **Publish**: call `mcp__plugin_fbg-core_atlassian__updateConfluencePage` with `status: "current"` (transitioning from draft). If `status` is not exposed on the update tool, the page is already live from Step 8 and this step is a no-op rename — proceed to Step 10.
+
+### Step 10 — Finalize
+
+```bash
+mv "$DRAFT_PATH" "$FINAL_PATH"
+```
+
+Update the frontmatter on the renamed file:
+
+- `status: published`
+- `published_at: <ISO 8601 with timezone offset>`
+
+Print the final summary:
+
+```
+One-pager published.
+
+  File:      raw/one-pagers/<slug>.md
+  Confluence: <url>
+  Title:     <title>
+  Rounds:    <n> review round(s) before approval
+```
+
+## Edge Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| `raw/one-pagers/` missing | `mkdir -p` in Step 2. |
+| Existing draft/final for the same slug | Step 2 asks Resume / Overwrite / Rename / Cancel. |
+| Draft over 700 words | Step 3 trims (or asks user to trim) before Step 4 dispatches reviewers. |
+| Reviewer agent returns malformed output | Treat as `verdict: revise` with no parsed edits; show the raw output to the user in the merged digest. |
+| All three reviewers approve on round 1 | Skip Step 5 incorporation. Still surface the three reports in the Step 6 digest so the user sees the verdicts. |
+| User picks Revise but makes no concrete request | Re-read the file fresh; if unchanged, ask explicitly: "What would you like changed?" before re-dispatching reviewers. |
+| Confluence auth missing/expired | Bail with `Atlassian access failed. Re-authenticate and re-run; your draft at <path> is preserved.` |
+| `createConfluencePage` schema lacks `status` field | Detected at Step 8.2. Ask the user via `AskUserQuestion` (Step 8.3) to confirm creating a live page before the call fires. On Continue, create without `status`; Step 9 publish becomes a no-op. On Cancel, exit with the local draft preserved. |
+| `createConfluencePage` accepts `status` but the request fails at runtime | Surface the error verbatim, do not retry silently. Ask the user whether to retry without `status` (same prompt as above) or cancel. |
+| User picks Cancel at Step 9 | Leave `confluence_page_id` and `confluence_url` populated in the draft's frontmatter so a re-run can pick up where it left off. |
+| Mid-step crash | Anything already persisted (draft on disk, Confluence page id in frontmatter) is preserved. Re-running the skill with the same title resumes via the Step 2 prompt. |
+
+## Examples
+
+### Example 1 — Happy path, single review round
+
+```
+User: /lyt-assistant:one-pager adopt Karpenter org-wide
+
+What's the audience? VP Eng + EKS team leads
+Authors? Ian Bartholomew
+Jira tickets? FANDEVX-2448
+What (outcome)? Reduce EKS capacity waste and pod-pending events across the org by migrating from cluster-autoscaler to a workload-aware node provisioner. (No tool prescription in this section.)
+Why? Q3 cost review flagged a $180k overrun in unused EKS capacity; FinOps wants a credible plan by end of month, and the pod-pending events are causing visible latency in identity flows.
+Other considerations? Node-replacement churn during cutover; security review needed for any new IAM roles.
+Additional reading? RFC-104 (cluster autoscaling alternatives), Q3 FinOps memo.
+
+Wrote draft: ~/Documents/Work/raw/one-pagers/.draft-adopt-karpenter-org-wide.md (512 words)
+
+Dispatching 3 reviewers in parallel...
+
+Reviewer round 1:
+  TPM: approve
+  Lead Platform Engineer: revise (2 issues)
+  Engineering Manager: approve
+
+Merged edits applied:
+  - What: removed "by deploying Karpenter" — too prescriptive, drifted into approach (Lead PE)
+  - Other Considerations: added "audit-log volume increase during pilot" (Lead PE)
+
+Word count: 528
+
+Draft ready. Review at raw/one-pagers/.draft-adopt-karpenter-org-wide.md.
+[Approve / Revise / Cancel] > Approve
+
+Creating Confluence draft under TechOps 1-Pagers...
+Created: https://betfanatics.atlassian.net/wiki/spaces/FAN/pages/1198273024 (draft)
+
+Review the Confluence draft. Ready to publish?
+[Publish / Revise / Cancel] > Publish
+
+Promoted draft to current.
+
+One-pager published.
+  File:      raw/one-pagers/adopt-karpenter-org-wide.md
+  Confluence: https://betfanatics.atlassian.net/wiki/spaces/FAN/pages/1198273024
+  Title:     Adopt Karpenter Org-Wide
+  Rounds:    1 review round before approval
+```
+
+### Example 2 — Two review rounds, user-initiated revision
+
+```
+[round 1 reviewers + edits as above]
+
+[Approve / Revise / Cancel] > Revise
+What would you like changed? Tighten What to one paragraph; the second paragraph is starting to read like a design.
+
+Applied edit. Re-dispatching 3 reviewers...
+
+Reviewer round 2:
+  TPM: approve
+  Lead Platform Engineer: approve
+  Engineering Manager: approve
+
+No new edits suggested. Word count: 498.
+
+[Approve / Revise / Cancel] > Approve
+...
+```
+
+### Example 3 — Resume an in-flight one-pager
+
+```
+User: /lyt-assistant:one-pager adopt Karpenter org-wide
+
+Found existing: raw/one-pagers/.draft-adopt-karpenter-org-wide.md
+[Resume / Overwrite / Rename / Cancel] > Resume
+
+Loaded draft (512 words). Skipping to review.
+...
+```
+
+## Related
+
+- `~/Documents/Work/wiki/concepts/one-pager-and-rfc.md` — canonical one-pager vs RFC reference. Read this if the user asks "what goes in a one-pager?" or pushes back on the section template.
+- `skills/research/SKILL.md` — sibling skill that follows the same draft → parallel reviewer → finalize pattern. Useful reference for the dispatch idiom.
+- `skills/meeting-action-items/SKILL.md` — sibling skill that uses interactive `AskUserQuestion` mid-loop with state preserved across interruptions.

--- a/stow-packages/claude/.claude/skills/rfc/SKILL.md
+++ b/stow-packages/claude/.claude/skills/rfc/SKILL.md
@@ -1,0 +1,563 @@
+---
+name: rfc
+description: This skill should be used when the user asks to "write an RFC", "draft an RFC", "make an RFC", "create a TechOps RFC", or runs "/rfc". Drafts a decision-focused TechOps RFC in raw/rfcs/ following the TechOps RFC Template (Confluence page 2097676435, FAN space) — metadata table (Authors / Publish Date / 1-Pager(s) / Epic(s) / Review Until Date / Status) and the seven canonical sections (Background, Goals & Scope, Current State, Possible Solutions evaluated across 10 lenses, Recommended Solution, Paths Not Taken, Open Questions). The user provides a starting prompt and the skill asks at least 3 clarifying questions. Runs two parallel agent personas (Senior Technical Product Manager, Principal Platform Engineer) for feedback, iterates with the user until approved, then copies the RFC template page into the TechOps RFC's parent (Confluence page 2053603380, FAN space) populated with the draft. Page stays DRAFT — the user clicks Publish manually.
+version: 0.1.0
+argument-hint: "[topic or starting prompt]"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Agent, mcp__plugin_fbg-core_atlassian__getAccessibleAtlassianResources, mcp__plugin_fbg-core_atlassian__getConfluencePage, mcp__plugin_fbg-core_atlassian__createConfluencePage, mcp__plugin_fbg-core_atlassian__updateConfluencePage]
+---
+
+# RFC Skill
+
+Draft, review, and stage a TechOps RFC end-to-end. The skill writes a draft to `raw/rfcs/`, runs **two** parallel agent reviewers (Senior Technical Product Manager, Principal Platform Engineer), iterates with the user, then creates a copy of the RFC template in Confluence under `TechOps RFC's` (parent page `2053603380`, space `FAN`) populated with the approved content. The Confluence page stays in `DRAFT` — the user clicks Publish themselves so the `#fes-rfcs` Slack notification fires under their identity.
+
+## When to Use
+
+Invoke this skill when:
+
+- User runs `/rfc` (with or without a topic argument)
+- User says "write an RFC", "draft an RFC", "make an RFC", "create a TechOps RFC", or any variation
+- User has a 1-pager that's been agreed to and now needs to make a concrete technical decision among multiple approaches
+
+## What an RFC is for (vs. a 1-pager)
+
+Per the user's wiki at `~/Documents/Work/wiki/concepts/one-pager-and-rfc.md` and the canonical Confluence guidance:
+
+- **1-pagers are the "what and why"** — persuasion artifacts for non-engineer decision-makers.
+- **RFCs are the detailed "how"** — commitment artifacts for the engineers who'll build it. The point of the RFC is to **make a decision** among multiple technical approaches and execute on it.
+- **One-pager first, always.** This skill strongly recommends a linked 1-pager and will nudge once if the user skips it. If skipped, leave a `TODO` in the 1-Pager(s) row of the metadata table.
+
+## Format Reference
+
+The canonical section structure is the **TechOps RFC Template** in Confluence (page id `2097676435`, FAN space). This skill mirrors that template exactly so drafts publish cleanly under the same parent.
+
+Metadata table (top of every page):
+
+| Field | Notes |
+|-------|-------|
+| **Author(s)** | One or more author names. Confluence template uses @ mentions; the skill writes display names. |
+| **Publish Date** | Leave blank for drafts; user will fill on Publish. |
+| **1-Pager(s)** | Link(s) to the related 1-pager. Strongly recommended. |
+| **Epic(s)** | Jira epic keys (e.g. `FANDEVX-2448`). Optional. |
+| **Review Until Date** | Date the review period ends and a decision is made. Optional but expected. |
+| **Document status** | `DRAFT` on create. The user transitions through `IN REVIEW` → `APPROVED` / `REJECTED` themselves. |
+
+Required body sections (in order):
+
+1. **🧭 Background & Motivation** — why now; problem or opportunity; prior work/incidents; summary of linked 1-pager(s).
+2. **🎯 Goals & Scope** — what we're aiming to achieve and explicit non-goals. Includes a **Requirements table** with columns: Requirement / User Story / Importance (HIGH/MEDIUM/LOW) / Notes.
+3. **🧱 Current State** *(optional — include only when replacing or evolving something)* — existing system, shortcomings, diagrams.
+4. **🧪 Possible Solutions** — 2–3 alternatives. **Every alternative is evaluated across the following 10 lenses.** Each lens must be addressed explicitly — even if the answer is "N/A — single-tenant, no compliance impact." Brevity is fine; absence is not.
+   - *System Behavior* — logical view; key components, responsibilities, interactions, data models. Diagrams help.
+   - *Deployment* — physical view; where it lives; environments, infrastructure, network topology.
+   - *Developer Experience* — code structure, repos, libraries, interfaces, ownership. Include only useful detail.
+   - *Observability* — logs, metrics, traces. How will we measure the system?
+   - *Security and Compliance* — auth, data handling, trust boundaries, compliance concerns.
+   - *Cost* — infra use, waste, efficiency. Big increases or savings?
+   - *Reliability* — operating concerns, SPoFs, failure modes, blast radius.
+   - *Maintainability* — tech debt, upgrade paths.
+   - *Tradeoffs & Risks* — third-party dependencies, internal blockers, untested assumptions.
+   - *Delivery Effort* — phased delivery; sequencing, not timelines; what ships independently; effort/resourcing.
+5. **🎺 Recommended Solution** — which alternative and why. Must tie back explicitly to the trade-offs analysis, not preference.
+6. **🛑 Paths Not Taken** — design paths explicitly not investigated, with rationale.
+7. **🤔 Open Questions** — what's still unclear, undecided, or under discussion.
+
+### Length & balance
+
+RFCs are denser than 1-pagers but must not bloat. Target ~1,500–2,500 words. Warn if below 500 (likely too thin) or above 4,000 (likely too verbose) before reviewers dispatch.
+
+Suggested per-section length:
+
+- Background: 1–3 paragraphs
+- Goals & Scope: bulleted goals + non-goals; Requirements table 3–7 rows
+- Current State: only when applicable; 1–3 paragraphs + diagram if helpful
+- Possible Solutions: 2–3 alternatives; each lens 1–2 paragraphs (or one sentence + "N/A" where genuinely not applicable)
+- Recommended Solution: 2–3 paragraphs, explicitly citing the trade-offs that drove the choice
+- Paths Not Taken / Open Questions: bullets
+
+## Paths
+
+All file paths are relative to the **vault root** (`~/Documents/Work/`):
+
+- Drafts: `raw/rfcs/.draft-<slug>.md`
+- Final: `raw/rfcs/<slug>.md`
+
+The dot-prefix on drafts mirrors the `one-pager` and `research` skill conventions and hides them from any `/compile`-style scanners.
+
+## Confluence constants
+
+| Item | Value |
+|---|---|
+| Space key | `FAN` |
+| Parent page (TechOps RFC's) | `2053603380` |
+| Template page (TechOps RFC Template) | `2097676435` |
+| Notification on Publish (handled by Confluence) | Slack `#fes-rfcs` |
+
+Cloud id is resolved at runtime via `getAccessibleAtlassianResources` (currently `efc5fcb9-cd3f-4ee1-8d0d-255a135bf4e8`).
+
+## Workflow
+
+### Step 1 — Gather input
+
+If the user passed a starting prompt on the command line (e.g. `/rfc karpenter ARM migration`), use it as the working title. Otherwise ask:
+
+```
+What's the working title for this RFC?
+```
+
+Then ask **at least three** clarifying questions, one at a time, conversational, accepting multi-line answers. Do **not** use `AskUserQuestion` for these — they're free text, not menu choices.
+
+**Required clarifying questions (ask all of these):**
+
+| # | Field | Prompt | Seeds section |
+|---|-------|--------|---------------|
+| 1 | Problem & motivation | What problem are we solving, or what opportunity are we acting on? Why is this coming up now? Any relevant incidents, deadlines, or prior decisions? | Background & Motivation |
+| 2 | Linked 1-pager(s) | What 1-pager backs this RFC? (path under `raw/one-pagers/` or a Confluence URL) | Metadata table |
+| 3 | Goals & non-goals | What does success look like — and what are we *explicitly* not solving here? Any hard requirements or constraints? | Goals & Scope |
+| 4 | Alternatives considered | What technical approaches have you already weighed? (At least the two or three you want compared. If only one, that's fine — name it and we'll surface a credible alternative or two for contrast.) | Possible Solutions |
+
+**Optional follow-ups (ask if not already covered):**
+
+- Author(s) — defaults to `Ian Bartholomew` if blank.
+- Jira epic(s) — comma-separated keys, e.g. `FANDEVX-2448, FESFEAT-428`. Leave blank to omit.
+- Review-until date — `YYYY-MM-DD`. Leave blank to omit.
+- Current state — is this replacing/evolving something? (If yes, the skill will include the optional **Current State** section; if no, omit it.)
+
+**1-pager nudge.** If the user skips question #2 (no path/URL provided), nudge **once**:
+
+```
+RFCs are the "how" — they generally come after a 1-pager that established the
+"what and why." Are you sure you want to proceed without one? I'll leave a TODO
+in the metadata table.
+```
+
+If they confirm, proceed and place `TODO — link 1-pager before publishing` in the `1-Pager(s)` row.
+
+### Step 2 — Pre-flight checks
+
+```bash
+VAULT_ROOT="$HOME/Documents/Work"
+RFCS_DIR="$VAULT_ROOT/raw/rfcs"
+mkdir -p "$RFCS_DIR"
+
+# Derive kebab-case slug from title
+SLUG=$(printf '%s' "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+
+DRAFT_PATH="$RFCS_DIR/.draft-$SLUG.md"
+FINAL_PATH="$RFCS_DIR/$SLUG.md"
+```
+
+If either `$DRAFT_PATH` or `$FINAL_PATH` already exists, ask via `AskUserQuestion`:
+
+- **Resume** — re-open the existing draft and skip ahead to Step 4
+- **Overwrite** — discard the existing file and write fresh
+- **Rename** — prompt for a new title and recompute the slug
+- **Cancel** — exit
+
+### Step 3 — Write the draft
+
+Write `$DRAFT_PATH` using the template below. Omit any optional section the user marked as not applicable (do not include a heading with placeholder filler). Always include all 10 lenses under each Possible Solution — using a single "N/A — <one-line reason>" when genuinely not applicable.
+
+```markdown
+---
+title: <Title>
+authors: <Authors>
+date: <YYYY-MM-DD>
+status: draft
+review_until: <YYYY-MM-DD or null>
+one_pager: <path or URL or null>
+jira_epics: <comma-separated keys or null>
+confluence_template_id: "2097676435"
+confluence_parent_id: "2053603380"
+confluence_space: FAN
+confluence_cloud_id: "efc5fcb9-cd3f-4ee1-8d0d-255a135bf4e8"
+confluence_page_id: null
+confluence_url: null
+---
+
+# <Title>
+
+| **Author(s)** | <Authors> |
+| --- | --- |
+| **Publish Date** | — |
+| **1-Pager(s)** | <link or `TODO — link 1-pager before publishing`> |
+| **Epic(s)** | <ticket keys or `—`> |
+| **Review Until Date** | <date or `—`> |
+| **Document status** | DRAFT |
+
+## 🧭 Background & Motivation
+
+<1–3 paragraphs. Why now; problem/opportunity; prior work or incidents; brief summary of the linked 1-pager(s) so this RFC stands on its own.>
+
+## 🎯 Goals & Scope
+
+**Goals**
+
+- <goal>
+- <goal>
+
+**Non-goals**
+
+- <non-goal>
+- <non-goal>
+
+**Requirements**
+
+| Requirement | User Story | Importance | Notes |
+|---|---|---|---|
+| <requirement> | <user story or N/A> | HIGH / MEDIUM / LOW | <notes> |
+
+## 🧱 Current State
+
+<Optional. Include only when replacing/evolving something. Describe existing system, shortcomings, limitations. Diagrams welcome.>
+
+## 🧪 Possible Solutions
+
+### Option A — <name>
+
+**System Behavior.** <…>
+
+**Deployment.** <…>
+
+**Developer Experience.** <…>
+
+**Observability.** <…>
+
+**Security and Compliance.** <…>
+
+**Cost.** <…>
+
+**Reliability.** <…>
+
+**Maintainability.** <…>
+
+**Tradeoffs & Risks.** <…>
+
+**Delivery Effort.** <phased delivery; what ships independently; effort/resourcing>
+
+### Option B — <name>
+
+<same 10 lenses>
+
+### Option C — <name>
+
+<same 10 lenses, if a third alternative is warranted>
+
+## 🎺 Recommended Solution
+
+<2–3 paragraphs. Which option and *why*, explicitly tied to the trade-offs above. Cite the specific lenses that drove the choice.>
+
+## 🛑 Paths Not Taken
+
+- <path>: <one-line rationale for not investigating>
+- <path>: <one-line rationale>
+
+## 🤔 Open Questions
+
+- <question>
+- <question>
+```
+
+**Length guard.** After writing, count words in the body (everything below the closing `---` of frontmatter):
+
+```bash
+WORDS=$(awk '/^---$/{c++; next} c>=2' "$DRAFT_PATH" | wc -w | tr -d ' ')
+```
+
+- 1,500–2,500 words: ideal.
+- 500–1,499 or 2,501–4,000: acceptable; note in reviewer dispatch which side it's on.
+- < 500 words: too thin. Push back to the user before dispatching reviewers — likely a lens or alternative is missing.
+- > 4,000 words: too verbose. Trim before Step 4.
+
+### Step 4 — Parallel persona review
+
+Dispatch **two `Agent` calls in a single message** (one tool-use block with two `Agent` calls). Each agent gets `Read`-only access — the main loop holds the pen.
+
+Use `subagent_type: "general-purpose"` for both. Pass the absolute draft path so each agent can `Read` it directly.
+
+**Shared response contract** (include in every persona prompt):
+
+```
+Return ONLY this format:
+
+  Top issues:
+    1. <issue>
+    2. <issue>
+    3. <issue>
+
+  Missing or unclear:
+    - <item>
+    - <item>
+
+  Suggested edits:
+    - <section>: <concrete edit>
+    - <section>: <concrete edit>
+
+  Verdict: approve | revise
+
+Keep your response under 300 words. Critique only — do not rewrite the RFC.
+```
+
+**Persona prompts** (substitute `<DRAFT_PATH>` with the absolute path):
+
+**Senior Technical Product Manager:**
+
+```
+You are a Senior Technical Product Manager reviewing a TechOps RFC at <DRAFT_PATH>.
+The doc follows the TechOps RFC Template: a metadata table (Author / Publish Date / 1-Pager(s) / Epic(s) / Review Until Date / Status), then Background & Motivation, Goals & Scope (with a Requirements table), an optional Current State, Possible Solutions (each evaluated across 10 lenses), Recommended Solution, Paths Not Taken, and Open Questions.
+
+Your concerns:
+- Is the business motivation tied to a concrete outcome — or does Background drift into solutioning?
+- Are Goals and Non-goals crisp and mutually exclusive? Are Requirements testable (clear acceptance criteria)?
+- Is the Recommended Solution defensible from a delivery and risk perspective — and does it cite the trade-offs that drove the choice, not preference?
+- Is incremental delivery clearly described (sequencing, what ships independently, decision checkpoints)? Are cross-team dependencies named?
+- Is the doc decision-ready, or do material unknowns hide in Open Questions that should be resolved first?
+
+Read the file, then return the response format described below.
+
+[shared response contract]
+```
+
+**Principal Platform Engineer:**
+
+```
+You are a Principal Platform Engineer reviewing a TechOps RFC at <DRAFT_PATH>.
+The doc follows the TechOps RFC Template: a metadata table (Author / Publish Date / 1-Pager(s) / Epic(s) / Review Until Date / Status), then Background & Motivation, Goals & Scope (with a Requirements table), an optional Current State, Possible Solutions (each evaluated across 10 lenses: System Behavior, Deployment, Developer Experience, Observability, Security and Compliance, Cost, Reliability, Maintainability, Tradeoffs & Risks, Delivery Effort), Recommended Solution, Paths Not Taken, and Open Questions.
+
+Your concerns:
+- Are the alternatives genuinely explored — or are some strawmen set up to make the recommendation look obvious? Are trade-offs sharp and honest?
+- Are all 10 lenses addressed for every alternative at appropriate depth? Where lenses say "N/A," is the rationale credible?
+- Are operational concerns covered: SLOs, failure modes, blast radius, rollback strategy, on-call impact?
+- Is the recommendation justified by the trade-off analysis itself — not by preference, vendor familiarity, or sunk cost?
+- Are Open Questions truly open, or are they unstated assumptions in disguise (i.e. things the recommendation depends on but doesn't acknowledge)?
+
+Read the file, then return the response format described below.
+
+[shared response contract]
+```
+
+### Step 5 — Incorporate reviewer feedback
+
+Merge the two reports. Group suggested edits by section. Deduplicate (the personas often flag the same thing from different angles).
+
+Apply edits to `$DRAFT_PATH` using `Edit`. Prefer surgical changes — don't rewrite passages the reviewers didn't flag.
+
+Show the user a compact digest before moving on:
+
+```
+Reviewer round 1:
+
+  Senior TPM:           revise (3 issues)
+  Principal Platform Engineer: revise (2 issues)
+
+  Merged edits applied:
+    - Possible Solutions / Option B / Observability: added trace propagation note (Principal PE)
+    - Recommended Solution: tied choice back to Cost + Delivery Effort lenses (Senior TPM, Principal PE)
+    - Goals & Scope: split conflated goal "reduce cost and migrate" into two requirements (Senior TPM)
+    - Open Questions: removed Q3 — was actually a decision dependency, moved to Recommended Solution caveat (Principal PE)
+
+  Word count: 1,872
+```
+
+### Step 6 — User review
+
+Print the draft path and a short summary of what changed. Then ask via `AskUserQuestion`:
+
+- **Approve** — proceed to Step 7 (Confluence draft creation)
+- **Revise** — describe what you'd like changed (or edit the file directly, then say "re-review")
+- **Cancel** — leave the draft on disk and exit
+
+If the user picks **Revise**, accept either:
+
+- inline change instructions in their answer → apply via `Edit`
+- a signal that they edited the file themselves → read the file fresh
+
+Then re-run Step 4 (parallel persona review) on the modified draft, incorporate per Step 5, and return to this step.
+
+**Termination:** the loop exits only when the user picks Approve or Cancel.
+
+**Iteration counter:** track rounds. After **3 rounds**, prepend the Step 6 prompt with:
+
+```
+You've done 3 review rounds. Continuing is fine, but this is also a good place
+to ship the RFC into Confluence and let the wider reviewers push back on real
+content rather than polish.
+```
+
+This is a nudge, not a hard cap.
+
+### Step 7 — Create the Confluence DRAFT
+
+Once the user approves at Step 6:
+
+1. **Promote the local file.**
+
+   ```bash
+   mv "$DRAFT_PATH" "$FINAL_PATH"
+   ```
+
+2. **Resolve cloud id.** Call `mcp__plugin_fbg-core_atlassian__getAccessibleAtlassianResources` and pick the `betfanatics` resource. Use that `id` as `cloudId` for all subsequent Confluence calls.
+
+3. **Verify connectivity.** Call `mcp__plugin_fbg-core_atlassian__getConfluencePage` with `cloudId` and `pageId: "2053603380"` to confirm the TechOps RFC's parent exists and is reachable. If 404 or auth fails, bail with a clear error and instructions to re-auth. The local file is preserved at `$FINAL_PATH`.
+
+4. **Optionally fetch the template** by calling `getConfluencePage` with `pageId: "2097676435"`. The skill already knows the template structure (it's embedded in this SKILL.md), so this call is only needed if you want to confirm the template hasn't drifted. Skip unless something looks off.
+
+5. **Inspect the `createConfluencePage` schema** (use `ToolSearch` with `query: "select:mcp__plugin_fbg-core_atlassian__createConfluencePage"` to load it if it isn't already in scope). Determine:
+
+   - Whether it accepts `spaceKey` (`"FAN"`) or requires `spaceId` (look up via `getConfluenceSpaces` if needed).
+   - Whether `status: "draft"` is exposed.
+   - Whether `body` accepts markdown directly or requires storage format.
+   - Whether `parentId` is the right param name (vs. `parentPageId`).
+
+6. **Pre-call confirmation gate.** If the schema does **not** expose `status: "draft"`, the page will be created as a live (current) page the moment the call fires. The user explicitly said they want this RFC to stay in DRAFT so they can publish themselves. Before calling, ask via `AskUserQuestion`:
+
+   ```
+   The MCP tool does not support draft pages. Creating this RFC will publish it
+   immediately as a live page under TechOps RFC's in the FAN space — which will
+   also fire the #fes-rfcs Slack notification. You wanted to publish manually.
+
+   Continue anyway, or cancel and create the page later via the Confluence UI?
+   [Continue / Cancel]
+   ```
+
+   If Cancel: exit with the local file at `$FINAL_PATH`. Print the file path and the parent Confluence URL so the user can copy/paste from the local doc into a manually-created page.
+
+   If `status: "draft"` is exposed, skip this prompt and proceed.
+
+7. **Create the page.** Call `mcp__plugin_fbg-core_atlassian__createConfluencePage` with:
+
+   - `cloudId`: from step 2.
+   - `spaceKey: "FAN"` (or `spaceId` from the lookup above).
+   - `parentId: "2053603380"`.
+   - `title`: the RFC title from frontmatter.
+   - `body`: the full markdown body (everything below the closing `---` of frontmatter). The template includes a markdown metadata table which Confluence renders natively. No images or macros on a fresh create.
+   - `contentFormat: "markdown"`.
+   - `status: "draft"` **only** if the schema accepted it.
+
+8. **Persist Confluence identity** — update the file's frontmatter via `Edit`:
+
+   - `status: confluence-draft`
+   - `confluence_page_id`: the returned page id
+   - `confluence_url`: the returned `_links.webui` (or equivalent absolute URL)
+
+9. **Hand back to the user.** Print:
+
+   ```
+   RFC drafted in Confluence.
+
+     File:       raw/rfcs/<slug>.md
+     Confluence: <url>   (status: DRAFT)
+     Title:      <title>
+     Rounds:     <n> review round(s) before approval
+
+   Review the Confluence page and click Publish yourself when ready.
+   Publishing fires the #fes-rfcs Slack notification under your identity.
+   ```
+
+   Do **not** call `updateConfluencePage` to promote `status: "current"`. That's the user's job.
+
+## Edge Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| `raw/rfcs/` missing | `mkdir -p` in Step 2. |
+| Existing draft/final for the same slug | Step 2 asks Resume / Overwrite / Rename / Cancel. |
+| Draft < 500 words | Step 3 pushes back to the user before dispatching reviewers — likely a missing lens or alternative. |
+| Draft > 4,000 words | Step 3 trims (or asks user to trim) before Step 4 dispatches reviewers. |
+| Only one alternative provided | At Step 1 / Step 3, prompt the user once for at least one credible alternative or strawman to contrast. If they insist on one alternative, write it that way and let the personas flag it. |
+| 1-pager link skipped | Nudge once at Step 1; if confirmed, place `TODO — link 1-pager before publishing` in the metadata table. |
+| Reviewer agent returns malformed output | Treat as `verdict: revise` with no parsed edits; show the raw output to the user in the merged digest. |
+| Both reviewers approve on round 1 | Skip Step 5 incorporation. Surface the two reports in the Step 6 digest so the user sees the verdicts. |
+| User picks Revise but makes no concrete request | Re-read the file fresh; if unchanged, ask explicitly: "What would you like changed?" before re-dispatching reviewers. |
+| Confluence auth missing/expired | Bail with `Atlassian access failed. Re-authenticate and re-run; your draft at <path> is preserved.` |
+| `createConfluencePage` schema lacks `status` field | Detected at Step 7.5. Ask the user via `AskUserQuestion` (Step 7.6) to confirm creating a live page (which fires the Slack notification) or cancel. Default expectation is cancel — user picked manual-publish for this skill. |
+| `createConfluencePage` accepts `status` but the request fails at runtime | Surface the error verbatim, do not retry silently. Ask the user whether to retry without `status` (same prompt as above) or cancel with the local file preserved. |
+| Mid-step crash after Confluence create | `confluence_page_id` and `confluence_url` are already persisted in frontmatter at Step 7.8. The user can find the draft in Confluence and either Publish or delete it from the UI. |
+
+## Examples
+
+### Example 1 — Happy path, single review round
+
+```
+User: /rfc karpenter ARM migration
+
+What problem are we solving / why now? We're running cluster-autoscaler on x86 nodes, costs are growing 18% QoQ, and Graviton instances are 20% cheaper for our workload mix. FinOps wants a decision by 2026-06-15.
+What 1-pager backs this RFC? raw/one-pagers/karpenter-org-wide.md
+Goals & non-goals? Goals: cut EKS compute spend by ≥15% within 90 days; preserve current pod-startup p99. Non-goals: rewriting workloads for ARM-native libraries; multi-arch images for everything (only the fleet's top 10 services).
+Alternatives considered? (1) Karpenter on Graviton with multi-arch images for top-10 services. (2) cluster-autoscaler with mixed instance pools including Graviton. (3) Stay on x86, focus on bin-packing improvements.
+Authors? Ian Bartholomew
+Jira epics? FANDEVX-2448
+Review-until date? 2026-06-15
+
+Wrote draft: ~/Documents/Work/raw/rfcs/.draft-karpenter-arm-migration.md (1,943 words)
+
+Dispatching 2 reviewers in parallel...
+
+Reviewer round 1:
+  Senior TPM:                 revise (2 issues)
+  Principal Platform Engineer: revise (3 issues)
+
+Merged edits applied:
+  - Option B / Reliability: added rollback-time estimate (Principal PE)
+  - Option C / Tradeoffs & Risks: surfaced "deferred-decision" cost (Senior TPM, Principal PE)
+  - Recommended Solution: explicitly cited Cost + Delivery Effort as the deciding lenses (Senior TPM)
+  - Goals & Scope: split "cut spend by 15%" and "preserve p99" into two rows in Requirements (Senior TPM)
+  - Open Questions: removed Q2 (it was a Recommended-Solution caveat, not an open question) (Principal PE)
+
+Word count: 2,037
+
+Draft ready. Review at raw/rfcs/.draft-karpenter-arm-migration.md.
+[Approve / Revise / Cancel] > Approve
+
+Creating Confluence draft under TechOps RFC's...
+Created: https://betfanatics.atlassian.net/wiki/spaces/FAN/pages/2197812345 (DRAFT)
+
+RFC drafted in Confluence.
+  File:       raw/rfcs/karpenter-arm-migration.md
+  Confluence: https://betfanatics.atlassian.net/wiki/spaces/FAN/pages/2197812345  (status: DRAFT)
+  Title:      Karpenter ARM Migration
+  Rounds:     1 review round before approval
+
+Review the Confluence page and click Publish yourself when ready.
+Publishing fires the #fes-rfcs Slack notification under your identity.
+```
+
+### Example 2 — Skip the 1-pager, get nudged
+
+```
+User: /rfc launchdarkly big segments cutover
+
+What problem are we solving / why now? <…>
+What 1-pager backs this RFC? (skipped)
+
+RFCs are the "how" — they generally come after a 1-pager that established the
+"what and why." Are you sure you want to proceed without one? I'll leave a TODO
+in the metadata table.
+
+> yes, this is small enough that the 1-pager would just be friction.
+
+Got it. Continuing.
+
+Goals & non-goals? <…>
+…
+```
+
+### Example 3 — Resume an in-flight RFC
+
+```
+User: /rfc karpenter ARM migration
+
+Found existing: raw/rfcs/.draft-karpenter-arm-migration.md
+[Resume / Overwrite / Rename / Cancel] > Resume
+
+Loaded draft (2,037 words). Skipping to review.
+…
+```
+
+## Related
+
+- `~/Documents/Work/wiki/concepts/one-pager-and-rfc.md` — canonical 1-pager vs. RFC doctrine. Read this if the user asks "what goes in an RFC?" or pushes back on the section template.
+- `~/Dev/lyt-assistant/skills/one-pager/SKILL.md` — sibling skill (1-pager) that follows the same draft → parallel reviewer → finalize pattern with three personas. Useful reference for the dispatch idiom and the Confluence MCP call sequence.
+- TechOps RFC Template — Confluence page `2097676435`, FAN space.
+- TechOps RFC's (parent) — Confluence page `2053603380`, FAN space.

--- a/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: start-of-day
+description: This skill should be used when the user asks to "start of day", "SOD", "run start of day", "kick off the day", "start of day routine", or runs "/start-of-day".
+version: 0.25.0
+allowed-tools:
+  [
+    Bash,
+    mcp__plugin_fbg-core_atlassian__searchJiraIssuesUsingJql,
+    mcp__plugin_fbg-core_atlassian__getJiraIssue,
+    Skill,
+  ]
+---
+
+# Start-of-Day Skill
+
+Gather the morning signal — open GitHub PRs, open JIRA tickets assigned to you, and Todoist tasks due today + overdue — and write it as three flat sections into today's Obsidian daily note.
+
+Layout is owned by a deterministic Python render script (`render.py` next to this file), so the model never composes the markdown by hand. The script:
+
+- Builds a nested JIRA forest from assigned tickets plus their reverse-traversed parent chain (root → child → grandchild …) and renders each ticket as a bulleted item with an embedded `####`/`#####`/`######` heading (capped at h6). Ancestor tickets that aren't assigned to you get a `· _(not assigned to you)_` suffix.
+- Extracts `FANDEVX-\d+` / `FESFEAT-\d+` keys from PR titles to render a bi-directional PR ↔ JIRA cross-link (`· JIRA: [KEY](url)` on PR rows, `· PRs: [#N](url)` on matching JIRA rows).
+- Flags assigned tickets as `· **🟢 Potential to close**` when the merged-PR set names the key but no open PR does — i.e., shipped work that no longer has open PRs. Ancestors never flag.
+- Prefixes JIRA status and priority with an emoji for at-a-glance scanning (📋/🚧/👀/🛑/✅/❌ for status; 🔥/🔴/🟡/🔵/⚪ for priority). 🟢 is reserved for "Potential to close". Unrecognised values render without a prefix.
+
+The skill now carries the full v0.17.0 feature set, end-to-end deterministic and owned by `render.py`.
+
+## Purpose
+
+The TUI is the wrong place for the morning snapshot — colours are flaky, the output scrolls away, and there's no record after the session ends. The snapshot is written into today's Obsidian daily note, which becomes the durable, searchable record of what was on the plate that morning.
+
+The skill is one-shot and non-interactive: fetch, write, confirm path, done. The user reviews and edits items in Obsidian (or via `td task update` / `gh` / JIRA directly) — this skill does not loop.
+
+## When to Use
+
+- User explicitly runs `/start-of-day`
+- User mentions "start of day", "SOD", "kick off the day", "start of day routine"
+
+## When NOT to Use
+
+- Only want today's todos: run `td today` directly
+- Want to edit one task: `td task update <ref>` directly
+- Only want open PRs or JIRA tickets: `gh search prs --author=ian-at-fes --state=open` or the Atlassian MCP search directly
+
+## Pipeline
+
+```
+  Fetch (parallel)  →  Render three flat sections  →  Upsert into today's
+  PRs / JIRA /         under a single ## Start          daily note (idempotent
+  Todoist              of Day heading                   via <!-- sod:* --> markers)
+                                                              ↓
+                                                  one confirmation line, exit
+```
+
+## Prerequisites
+
+- **`gh` CLI authed as `ian-at-fes`.** The skill runs `gh auth switch --user ian-at-fes` before any `gh` call. Pin `--author=ian-at-fes` explicitly — never `--author @me` (it silently falls back to the personal account and hides org PRs).
+- **Atlassian MCP available** (`mcp__plugin_fbg-core_atlassian__searchJiraIssuesUsingJql`).
+- **Todoist CLI (`td`) authed.** Fallback absolute path: `/opt/homebrew/bin/td`.
+- **Obsidian app running** with Daily Notes enabled. The `obsidian` CLI talks to the live app and exits non-zero otherwise. Full reference: <https://help.obsidian.md/cli>.
+
+## Process Flow
+
+### Step 1: Locate today's daily note
+
+```bash
+obsidian daily                              # ensure today's note exists
+DAILY_NOTE_PATH="$(obsidian daily:path)"    # canonical absolute path
+```
+
+Never construct the path manually. Obsidian's Daily Notes / Periodic Notes plugin owns the location and filename format — whatever `obsidian daily:path` returns is the only correct destination. If `obsidian daily` exits non-zero, see §Error Handling.
+
+### Step 2: Fetch all sources in parallel
+
+Issue these tool uses in a single assistant message so they execute concurrently.
+
+1. **Bash — GitHub PRs (open):**
+
+   ```bash
+   gh auth switch --user ian-at-fes && \
+   gh search prs --author=ian-at-fes --state=open \
+     --json number,title,url,repository,isDraft,updatedAt \
+     --limit 500
+   ```
+
+1a. **Bash — GitHub PRs (merged), for the "🟢 Potential to close" flag:**
+
+```bash
+gh search prs --involves=ian-at-fes --state=closed --merged \
+  --json number,title,url,repository \
+  --limit 500
+```
+
+The merged query uses `--involves` (not `--author`) on purpose: the flag is meant to catch shipped work that closed a ticket assigned to you, regardless of who authored the PR. A teammate's merged PR that names `FANDEVX-NNNN` in its title should still flag the corresponding assigned ticket as closeable. The open-PR query above keeps `--author=ian-at-fes` because the PR section of the daily note is "what's on _your_ plate" — reviewer-only PRs there would just add noise.
+
+This call is best-effort: if it fails, write `{"error": "<msg>"}` to `/tmp/sod-merged-prs.json` and the flag simply won't fire.
+
+1. **Atlassian MCP — JIRA tickets + parent-chain traversal:**
+
+   First, search for assigned tickets:
+
+   - **Tool:** `mcp__plugin_fbg-core_atlassian__searchJiraIssuesUsingJql`
+   - **cloudId:** `efc5fcb9-cd3f-4ee1-8d0d-255a135bf4e8`
+   - **JQL:** `assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC`
+   - **Fields:** `summary, status, priority, updated, issuetype, parent`
+
+   Then walk each ticket's `parent` chain up to the topmost ancestor — even when those ancestors are not assigned to you — so the nested rendering can show the epic / feature context. Algorithm:
+
+   1. Seed a map `nodes_by_key` from the search result. Mark each as `assignedToMe: true`.
+   2. For every ticket with a `parent.key` not already in the map, call `mcp__plugin_fbg-core_atlassian__getJiraIssue` (same cloudId, same `fields` list) to fetch that ancestor. Mark fetched ancestors as `assignedToMe: false`. Add them to the map.
+   3. Repeat for the ancestor's own `parent.key`, and so on. **Dedup aggressively — never fetch the same key twice in one run.** Different assigned tickets often share ancestor chains.
+   4. **Depth cap: 6 hops.** If traversal would go deeper, stop and accept that some far ancestors won't appear.
+
+   Write the **merged** map to `/tmp/sod-jira.json` as `{"issues": [...]}` — one entry per ticket (assigned + ancestor), each with `key`, `assignedToMe`, and a `fields` object containing `summary, status, priority, issuetype, updated, parent`. The render script reads this shape and builds the forest itself; no traversal logic in the script.
+
+2. **Bash — Todoist:**
+
+   ```bash
+   td today --json
+   ```
+
+After all three fetches return (or fail), persist each result to a temp JSON file for Step 3 to consume:
+
+- **Open PRs (success):** write the raw `gh search prs --state=open --json …` output to `/tmp/sod-prs.json`.
+- **Merged PRs (success):** write the raw `gh search prs --state=closed --merged --json …` output to `/tmp/sod-merged-prs.json`.
+- **JIRA (success):** write the raw Atlassian MCP response (object with an `issues` array) to `/tmp/sod-jira.json`.
+- **Todoist (success):** write the raw `td today --json` output to `/tmp/sod-todoist.json`.
+- **Any source fails:** write `{"error": "<message>"}` to that source's file instead of a payload. Other sources still write their normal output.
+
+The render script in Step 3 reads these three files and emits the corresponding section text — including the `_… lookup failed: <error>._` line for any source whose file contains an `error` shape.
+
+### Step 3: Invoke the render script
+
+The skill no longer composes markdown by hand. A deterministic Python script at `~/.claude/skills/start-of-day/render.py` reads the three JSON files written in Step 2 and emits the entire `## Start of Day` … `<!-- sod:end -->` block on stdout. The script owns whitespace and structure; the model captures stdout and uses it verbatim in Step 4.
+
+```bash
+python3 ~/.claude/skills/start-of-day/render.py \
+  --prs /tmp/sod-prs.json \
+  --jira /tmp/sod-jira.json \
+  --todoist /tmp/sod-todoist.json \
+  --merged-prs /tmp/sod-merged-prs.json \
+  --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+The script uses Python 3 stdlib only — no `pip install`, no extra setup. It works against whatever Python 3 ships on the system. Optional `--now <iso>` overrides the reference time used for "updated Nh/Nd ago" math (useful only for fixture-based testing).
+
+The captured stdout is opaque to the model — do **not** edit it before Step 4. The byte stream from `python3 render.py …` is exactly what goes into the daily note.
+
+If the script exits non-zero, halt and surface the stderr to the user — that signals a malformed JSON file from Step 2.
+
+Test fixtures live at `~/.claude/skills/start-of-day/test-fixtures/`. To verify the script standalone:
+
+```bash
+cd ~/.claude/skills/start-of-day
+./render.py --prs test-fixtures/sample-prs.json \
+            --jira test-fixtures/sample-jira.json \
+            --todoist test-fixtures/sample-todoist.json \
+            --generated-at 2026-05-13T22:40:20Z \
+            --now 2026-05-13T22:40:20Z
+```
+
+The output shape is unchanged from v0.18.0 — three flat sections, `_None._` for empty lists (or the Todoist-specific empty line), `_<Section> — lookup failed: <message>._` for an error source.
+
+### Step 4: Upsert the section into today's daily note
+
+Idempotent — re-running the same day MUST replace the previous section, not duplicate it.
+
+**Case A — first run today (markers absent):** append via `obsidian daily:append`:
+
+```bash
+obsidian daily:append content="$(cat <<'EOF'
+
+## Start of Day
+
+<!-- sod:begin generated=… -->
+...full rendered section...
+<!-- sod:end -->
+EOF
+)"
+```
+
+The leading blank line in the heredoc separates the new section from whatever ended the daily note already.
+
+**Case B — re-run today (markers present):** read → splice → write. Use `$DAILY_NOTE_PATH` from Step 1:
+
+1. Read the current note via the `Read` tool against `$DAILY_NOTE_PATH` (or `obsidian daily:read`).
+2. Find the `## Start of Day` heading and the matching `<!-- sod:begin … -->` / `<!-- sod:end -->` markers. Delete everything from the heading line through and including the `<!-- sod:end -->` line.
+3. Splice the freshly-rendered section into the same position.
+4. Write the result back to `$DAILY_NOTE_PATH` via `Write` or `Edit`.
+
+Detection: if `obsidian daily:read` contains the literal `<!-- sod:begin`, you're in Case B; otherwise Case A.
+
+**Never** edit by line number or by blind regex on the whole file. The `<!-- sod:begin` / `<!-- sod:end -->` markers are the only contract; anything outside them is the user's.
+
+After the write, verify: `obsidian daily:read | grep -c '<!-- sod:begin'` must return `1`. If it returns `0` or `>1`, see §Error Handling.
+
+### Step 5: Confirm in the terminal and exit
+
+Print one short, plain-text line and stop. No edit loop:
+
+```
+Start of Day written to: <absolute path>
+  PRs: <N>  ·  JIRA: <N>  ·  Todoist: <N>
+```
+
+## Error Handling
+
+- **`gh` failure:** render the PR section as `_Open Pull Requests — lookup failed: <error>._` and continue.
+- **JIRA MCP failure:** render the JIRA section as `_Open JIRA Tickets — lookup failed: <error>._` and continue.
+- **`td` failure:** render the Todoist section as `` _Today + Overdue — `td` unavailable: <error>._ `` and continue.
+- **`obsidian daily` failure** (most common cause: Obsidian not running): print the error and tell the user `Obsidian doesn't appear to be running — open the app, then re-run /start-of-day. Falling back to terminal output for this run.` Emit the markdown to the terminal as a one-time fallback.
+- **Post-write marker count != 1:** print a diagnostic with `$DAILY_NOTE_PATH` and halt — ask the user to inspect the daily note manually before re-running.
+
+## Related Skills
+
+- **/end-of-day** — End-of-day counterpart
+- **`obsidian` CLI** — Daily-note ops; full reference at <https://help.obsidian.md/cli>
+- **todoist-cli** — `td` CLI syntax reference
+
+## Summary
+
+`/start-of-day` fetches open GitHub PRs, assigned open JIRA tickets, and Todoist due-today + overdue tasks in parallel, then writes three flat bulleted sections into today's Obsidian daily note under a `## Start of Day` heading bracketed by `<!-- sod:begin -->` / `<!-- sod:end -->` markers. The write is idempotent (re-running the same day replaces the section). The skill is one-shot and non-interactive: a single confirmation line prints once the note is written, then the skill exits.
+
+From v0.19.0 the markdown is emitted by `render.py` (Python 3 stdlib) rather than composed by the model — the model writes the three fetch results to JSON files, invokes the script, and splices the script's stdout into the daily note. JIRA parent traversal, PR↔JIRA cross-linking, Potential-to-close, and emoji prefixes were intentionally left out of this baseline; they will be added to the script in subsequent versions.

--- a/stow-packages/claude/.claude/skills/start-of-day/render.py
+++ b/stow-packages/claude/.claude/skills/start-of-day/render.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Render the /start-of-day daily-note section from three fetch-result JSON files.
+
+The model writes gh / JIRA / Todoist fetch results to JSON, invokes this script,
+and splices the stdout block into today's Obsidian daily note. The model never
+composes the markdown itself, eliminating whitespace drift.
+
+Output is the full block from `## Start of Day` through `<!-- sod:end -->` on
+stdout, terminated by a trailing newline. Byte-identical to v0.18.0's hand-
+rendered shape so this version is a pure refactor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+JIRA_BASE = "https://betfanatics.atlassian.net/browse/"
+KEY_RE = re.compile(r"(?:FANDEVX|FESFEAT)-\d+")
+
+# Status / priority emoji prefixes — lowercased lookup. Unknown values render
+# without a prefix. 🟢 is reserved for "Potential to close" and must NOT appear
+# in either table.
+STATUS_EMOJI = {
+    "to do": "📋", "backlog": "📋", "open": "📋", "new": "📋",
+    "in progress": "🚧", "in development": "🚧",
+    "in review": "👀", "code review": "👀", "qa": "👀",
+    "blocked": "🛑", "on hold": "🛑", "waiting": "🛑",
+    "done": "✅", "closed": "✅", "resolved": "✅",
+    "cancelled": "❌", "canceled": "❌", "won't do": "❌", "wont do": "❌",
+}
+PRIORITY_EMOJI = {
+    "highest": "🔥", "p0": "🔥", "critical": "🔥",
+    "high": "🔴", "p1": "🔴",
+    "medium": "🟡", "p2": "🟡",
+    "low": "🔵", "p3": "🔵",
+    "lowest": "⚪", "p4": "⚪",
+}
+
+
+def status_emoji(name: str) -> str:
+    return STATUS_EMOJI.get((name or "").strip().lower(), "")
+
+
+def priority_emoji(name: str) -> str:
+    return PRIORITY_EMOJI.get((name or "").strip().lower(), "")
+
+
+def extract_keys(text: str) -> list[str]:
+    """Return unique JIRA keys found in `text`, preserving first-seen order."""
+    return list(dict.fromkeys(KEY_RE.findall(text or "")))
+
+
+def build_crosslinks(prs_data):
+    """Return (keys_by_pr_number, prs_by_key) from the PR list.
+
+    keys_by_pr_number: { PR_NUMBER: [KEY, ...] } — keys parsed from PR titles.
+    prs_by_key:        { KEY: [(PR_NUMBER, PR_URL), ...] } — inverse map.
+
+    Both maps are empty when PR data is missing or errored — JIRA rows then
+    render without a PRs suffix and PR rows without a JIRA suffix.
+    """
+    keys_by_pr_number: dict = {}
+    prs_by_key: dict = {}
+    if not isinstance(prs_data, list):
+        return keys_by_pr_number, prs_by_key
+    for pr in prs_data:
+        number = pr.get("number")
+        url = pr.get("url", "")
+        keys = extract_keys(pr.get("title", ""))
+        if not keys:
+            continue
+        keys_by_pr_number[number] = keys
+        for k in keys:
+            prs_by_key.setdefault(k, []).append((number, url))
+    return keys_by_pr_number, prs_by_key
+
+
+def build_merged_count_by_key(merged_prs_data):
+    """Return {KEY: int} — merged-PR count per JIRA key, parsed from PR titles.
+
+    Empty when the merged-PR data is missing or errored. The "Potential to
+    close" flag then never fires (silently degraded).
+    """
+    counts: dict = {}
+    if not isinstance(merged_prs_data, list):
+        return counts
+    for pr in merged_prs_data:
+        for k in extract_keys(pr.get("title", "")):
+            counts[k] = counts.get(k, 0) + 1
+    return counts
+
+
+def parse_iso(s: str) -> datetime:
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+def load_source(path: Path):
+    """Return (data, error_message). Treats a `{"error": "..."}` payload as a
+    fetch failure for that source; the section then renders the failure line."""
+    try:
+        raw = path.read_text()
+        data = json.loads(raw)
+    except FileNotFoundError:
+        return None, f"input file not found: {path}"
+    except json.JSONDecodeError as e:
+        return None, f"invalid JSON in {path.name}: {e}"
+    if isinstance(data, dict) and set(data.keys()) == {"error"}:
+        return None, str(data["error"])
+    return data, None
+
+
+def relative_time(updated_at: datetime, now: datetime) -> str:
+    delta = now - updated_at
+    hours = int(delta.total_seconds() // 3600)
+    if hours < 0:
+        hours = 0
+    if hours < 24:
+        return f"{hours}h"
+    return f"{hours // 24}d"
+
+
+def render_prs(data, error, now: datetime, keys_by_pr_number) -> str:
+    if error is not None:
+        return "\n".join([
+            "### Open Pull Requests (0)",
+            "",
+            f"_Open Pull Requests — lookup failed: {error}._",
+        ])
+    prs = data or []
+    out = [f"### Open Pull Requests ({len(prs)})", ""]
+    if not prs:
+        out.append("_None._")
+        return "\n".join(out)
+    for pr in prs:
+        repo = (pr.get("repository") or {}).get("nameWithOwner", "?/?")
+        num = pr.get("number", "?")
+        url = pr.get("url", "")
+        title = pr.get("title", "(no title)")
+        updated_raw = pr.get("updatedAt")
+        rel = relative_time(parse_iso(updated_raw), now) if updated_raw else "?"
+        draft = " · _(draft)_" if pr.get("isDraft") else ""
+        keys = keys_by_pr_number.get(num) or []
+        jira_suffix = ""
+        if keys:
+            jira_suffix = " · JIRA: " + ", ".join(f"[{k}]({JIRA_BASE}{k})" for k in keys)
+        out.append(
+            f"- [{repo}#{num}]({url}) — {title} · _updated {rel} ago_{draft}{jira_suffix}"
+        )
+    return "\n".join(out)
+
+
+def _heading_for_depth(depth: int) -> str:
+    """Return the `####`-family heading marker for a node at `depth` (root=0)."""
+    return "#" * min(4 + depth, 6)
+
+
+def _jira_node_lines(node, depth: int, children_by_key, prs_by_key, merged_count_by_key) -> list[str]:
+    """Render one node and recursively render its children. Returns list of lines."""
+    indent = "    " * depth
+    key = node["key"]
+    summary = node["summary"]
+    status = node["status"]
+    prio = node["priority"]
+    itype = node["issuetype"]
+    assigned = node["assignedToMe"]
+    heading = _heading_for_depth(depth)
+    if depth == 0:
+        title_md = f"{heading} {summary} [{key}]({JIRA_BASE}{key})"
+    else:
+        title_md = f"{heading} **{summary}** [{key}]({JIRA_BASE}{key})"
+    not_assigned_suffix = "" if assigned else " · _(not assigned to you)_"
+    matched_prs = prs_by_key.get(key) or []
+    # "Potential to close" fires only for assigned tickets with at least one
+    # merged PR and zero open PRs referencing the key. Ancestors never flag —
+    # closing them isn't the user's call.
+    potential_suffix = ""
+    if assigned and merged_count_by_key.get(key, 0) >= 1 and not matched_prs:
+        potential_suffix = " · **🟢 Potential to close**"
+    s_emoji = status_emoji(status)
+    p_emoji = priority_emoji(prio)
+    status_md = f"{s_emoji} `{status}`" if s_emoji else f"`{status}`"
+    prio_md = f"{p_emoji} `{prio}`" if p_emoji else f"`{prio}`"
+    meta = f"{status_md} · {prio_md} · _{itype}_{potential_suffix}{not_assigned_suffix}"
+    lines = [f"{indent}- {title_md}", f"{indent}    - {meta}"]
+    if matched_prs:
+        prs_md = ", ".join(f"[#{n}]({u})" for n, u in matched_prs)
+        lines.append(f"{indent}    - PRs: {prs_md}")
+    for child in children_by_key.get(key, []):
+        lines.extend(_jira_node_lines(child, depth + 1, children_by_key, prs_by_key, merged_count_by_key))
+    return lines
+
+
+def _normalise_jira_node(issue):
+    """Project a raw MCP issue into the flat shape the renderer expects."""
+    f = issue.get("fields") or {}
+    parent = issue.get("parent") or f.get("parent") or {}
+    parent_key = parent.get("key") if isinstance(parent, dict) else None
+    return {
+        "key": issue.get("key", "?"),
+        "summary": f.get("summary", "(no summary)"),
+        "status": (f.get("status") or {}).get("name") or "(unknown)",
+        "priority": (f.get("priority") or {}).get("name") or "(none)",
+        "issuetype": (f.get("issuetype") or {}).get("name") or "(unknown)",
+        "updated": f.get("updated") or "",
+        "parent_key": parent_key,
+        "assignedToMe": bool(issue.get("assignedToMe", True)),
+    }
+
+
+def render_jira(data, error, prs_by_key, merged_count_by_key) -> str:
+    if error is not None:
+        return "\n".join([
+            "### Open JIRA Tickets (0 assigned · 0 top-level · 0 total)",
+            "",
+            f"_Open JIRA Tickets — lookup failed: {error}._",
+        ])
+    raw = (data or {}).get("issues", []) if isinstance(data, dict) else []
+    nodes = [_normalise_jira_node(i) for i in raw]
+    by_key = {n["key"]: n for n in nodes}
+    children_by_key: dict = {}
+    roots = []
+    for n in nodes:
+        pk = n["parent_key"]
+        if pk and pk in by_key:
+            children_by_key.setdefault(pk, []).append(n)
+        else:
+            roots.append(n)
+    # Sort siblings by updated DESC at every level.
+    for siblings in children_by_key.values():
+        siblings.sort(key=lambda x: x["updated"], reverse=True)
+    roots.sort(key=lambda x: x["updated"], reverse=True)
+
+    assigned_count = sum(1 for n in nodes if n["assignedToMe"])
+    out = [
+        f"### Open JIRA Tickets ({assigned_count} assigned · {len(roots)} top-level · {len(nodes)} total)",
+        "",
+    ]
+    if not nodes:
+        out.append("_None._")
+        return "\n".join(out)
+    for root in roots:
+        out.extend(_jira_node_lines(root, 0, children_by_key, prs_by_key, merged_count_by_key))
+    return "\n".join(out)
+
+
+def render_todoist(data, error, now: datetime) -> str:
+    if error is not None:
+        return "\n".join([
+            "### Today + Overdue (0)",
+            "",
+            f"_Today + Overdue — `td` unavailable: {error}._",
+        ])
+    # `td today --json` returns {"results": [...], "nextCursor": ...}; older
+    # versions / fixtures may return a bare list. Accept both.
+    if isinstance(data, dict):
+        tasks = data.get("results", []) or []
+    else:
+        tasks = data or []
+    out = [f"### Today + Overdue ({len(tasks)})", ""]
+    if not tasks:
+        out.append("_Nothing due today, nothing overdue._")
+        return "\n".join(out)
+    today_local = now.astimezone().date()
+    for task in tasks:
+        prio = task.get("priority", 4)
+        url = task.get("url", "")
+        content = task.get("content", "(no content)")
+        # `due.date` may be a bare date ("2026-05-13") or a datetime
+        # ("2026-05-13T19:00:00"). Either way the first 10 chars are the date.
+        due_raw = (task.get("due") or {}).get("date") or ""
+        days_overdue = 0
+        if due_raw:
+            try:
+                due_date = datetime.strptime(due_raw[:10], "%Y-%m-%d").date()
+                days_overdue = (today_local - due_date).days
+            except ValueError:
+                days_overdue = 0
+        if days_overdue > 0:
+            prefix = f"**⏰ overdue {days_overdue}d**"
+        else:
+            prefix = "**due today**"
+        out.append(f"- {prefix} · priority `p{prio}` — [{content}]({url})")
+    return "\n".join(out)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--prs", required=True, type=Path)
+    p.add_argument("--jira", required=True, type=Path)
+    p.add_argument("--todoist", required=True, type=Path)
+    p.add_argument("--merged-prs", default=None, type=Path,
+                   help="Optional. PRs the user merged (gh search prs --state=closed --merged). "
+                        "Feeds the 🟢 Potential to close flag. Omit to disable the flag.")
+    p.add_argument("--generated-at", required=True,
+                   help="ISO-8601 UTC timestamp for the <!-- sod:begin --> marker")
+    p.add_argument("--now", default=None,
+                   help="ISO-8601 reference time for relative-time math (default: now)")
+    args = p.parse_args()
+
+    now = parse_iso(args.now).astimezone(timezone.utc) if args.now else datetime.now(timezone.utc)
+
+    prs_data, prs_err = load_source(args.prs)
+    jira_data, jira_err = load_source(args.jira)
+    td_data, td_err = load_source(args.todoist)
+
+    keys_by_pr_number, prs_by_key = build_crosslinks(prs_data)
+
+    merged_count_by_key: dict = {}
+    if args.merged_prs is not None:
+        merged_data, _ = load_source(args.merged_prs)
+        merged_count_by_key = build_merged_count_by_key(merged_data)
+
+    blocks = [
+        "## Start of Day",
+        "",
+        f"<!-- sod:begin generated={args.generated_at} -->",
+        "",
+        render_prs(prs_data, prs_err, now, keys_by_pr_number),
+        "",
+        render_jira(jira_data, jira_err, prs_by_key, merged_count_by_key),
+        "",
+        render_todoist(td_data, td_err, now),
+        "",
+        "<!-- sod:end -->",
+    ]
+    sys.stdout.write("\n".join(blocks) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-jira.json
+++ b/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-jira.json
@@ -1,0 +1,74 @@
+{
+  "issues": [
+    {
+      "key": "FANDEVX-2596",
+      "assignedToMe": true,
+      "fields": {
+        "summary": "Enable FBG Access to FES Fanflow Kafka - prod (609732359649)",
+        "status": { "name": "In Progress" },
+        "priority": { "name": "Medium" },
+        "issuetype": { "name": "Story" },
+        "updated": "2026-05-12T16:00:00Z",
+        "parent": { "key": "FANDEVX-2598" }
+      }
+    },
+    {
+      "key": "FANDEVX-2594",
+      "assignedToMe": true,
+      "fields": {
+        "summary": "Enable FBG Access to FES Fanflow Kafka - test (610756916101)",
+        "status": { "name": "In Progress" },
+        "priority": { "name": "Medium" },
+        "issuetype": { "name": "Story" },
+        "updated": "2026-05-11T16:00:00Z",
+        "parent": { "key": "FANDEVX-2598" }
+      }
+    },
+    {
+      "key": "FANDEVX-2598",
+      "assignedToMe": false,
+      "fields": {
+        "summary": "Enable FBG to Subscribe/Publish to Topics from FES Fanflow",
+        "status": { "name": "In Progress" },
+        "priority": null,
+        "issuetype": { "name": "Epic" },
+        "updated": "2026-05-10T16:00:00Z",
+        "parent": { "key": "FESFEAT-597" }
+      }
+    },
+    {
+      "key": "FESFEAT-597",
+      "assignedToMe": false,
+      "fields": {
+        "summary": "[INJECTION] Enable FBG to Subscribe/Publish to Topics from FES Fanflow",
+        "status": { "name": "In Progress" },
+        "priority": null,
+        "issuetype": { "name": "Feature" },
+        "updated": "2026-05-09T16:00:00Z"
+      }
+    },
+    {
+      "key": "FANDEVX-2724",
+      "assignedToMe": true,
+      "fields": {
+        "summary": "IDP 1.5: Entity Definitions — Scale (Batch 2) + Adoption Strategy",
+        "status": { "name": "In Progress" },
+        "priority": { "name": "Medium" },
+        "issuetype": { "name": "Story" },
+        "updated": "2026-05-08T16:00:00Z",
+        "parent": { "key": "FANDEVX-2719" }
+      }
+    },
+    {
+      "key": "FANDEVX-2719",
+      "assignedToMe": false,
+      "fields": {
+        "summary": "Datadog IDP: Software Catalog Foundation",
+        "status": { "name": "Done" },
+        "priority": { "name": "Medium" },
+        "issuetype": { "name": "Epic" },
+        "updated": "2026-05-07T16:00:00Z"
+      }
+    }
+  ]
+}

--- a/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-merged-prs.json
+++ b/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-merged-prs.json
@@ -1,0 +1,8 @@
+[
+  {
+    "number": 2200,
+    "title": "FANDEVX-2724: ship batch 2 entity definitions",
+    "url": "https://github.com/fanatics-gaming/fanapp-terraform/pull/2200",
+    "repository": { "nameWithOwner": "fanatics-gaming/fanapp-terraform" }
+  }
+]

--- a/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-prs.json
+++ b/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-prs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "number": 2227,
+    "title": "feat: add fanapp-perf core infrastructure Terraform config",
+    "url": "https://github.com/fanatics-gaming/fanapp-terraform/pull/2227",
+    "repository": { "nameWithOwner": "fanatics-gaming/fanapp-terraform" },
+    "isDraft": true,
+    "updatedAt": "2026-05-12T18:23:11Z"
+  },
+  {
+    "number": 2215,
+    "title": "FANDEVX-2596 : Enable FES access to FBG Fanflow Kafka prod cluster",
+    "url": "https://github.com/fanatics-gaming/fanapp-terraform/pull/2215",
+    "repository": { "nameWithOwner": "fanatics-gaming/fanapp-terraform" },
+    "isDraft": false,
+    "updatedAt": "2026-04-22T18:23:11Z"
+  }
+]

--- a/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-todoist.json
+++ b/stow-packages/claude/.claude/skills/start-of-day/test-fixtures/sample-todoist.json
@@ -1,0 +1,14 @@
+[
+  {
+    "content": "Review FANDEVX-2724 closure",
+    "priority": 2,
+    "due": { "date": "2026-05-10" },
+    "url": "https://app.todoist.com/app/task/abc123"
+  },
+  {
+    "content": "Pick up dry cleaning",
+    "priority": 3,
+    "due": { "date": "2026-05-13" },
+    "url": "https://app.todoist.com/app/task/def456"
+  }
+]

--- a/stow-packages/claude/.claude/skills/start-ticket/SKILL.md
+++ b/stow-packages/claude/.claude/skills/start-ticket/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: start-ticket
+description: Start working on a JIRA ticket — fetches ticket details, creates a git worktree on a new branch, and plans the implementation using superpowers.
+arguments:
+  - name: ticket
+    description: JIRA ticket key (e.g. FANDEVX-1234)
+    required: true
+---
+
+# Start Ticket Workflow
+
+You are starting work on JIRA ticket `$ARGUMENTS.ticket`. Follow these steps in order:
+
+## Step 1: Fetch the JIRA ticket
+
+Use the Atlassian MCP tools to fetch the ticket details:
+
+- Get the issue summary, description, acceptance criteria, and status
+- If the ticket is a sub-task, also fetch the parent story for context
+- If the ticket is a story, also fetch the parent epic for context
+- Note any linked/blocking tickets
+- If the ticket has subtasks, prompt the user if they want to work on one task in particular.
+- Assign the ticket to the user.
+
+Present a brief summary of the ticket to the user before proceeding.
+
+## Step 2: Create a git worktree
+
+Create an isolated git worktree for this work:
+
+- Detect the current git repository from the working directory
+- Create a new branch named `{ticket-key}/{slugified-summary}` (e.g. `FANDEVX-2505/submit-aws-account-request`)
+  - Slugify the summary: lowercase, replace spaces with hyphens, remove special characters, truncate to 50 chars
+- Use the `using-git-worktrees` skill from superpowers to create the worktree safely
+- If the worktree skill is not available, fall back to manual `git worktree add` commands
+
+## Step 3: Plan the work
+
+Once in the worktree:
+
+- Use the `superpowers:brainstorm` skill from superpowers to create an implementation plan
+- Feed the JIRA ticket details (summary, description, AC, parent context) into the brainstorm
+- The plan should identify:
+  - What files need to be created or modified
+  - What the implementation approach is
+  - How to verify the work is complete (based on AC)
+
+## Important Notes
+
+- Always use superpowers to plan the work
+- If the ticket is already "In Progress", warn the user that work may already be underway
+- If the ticket has blockers that aren't resolved, warn the user
+- Transition the ticket to "In Progress" after the worktree is created (ask the user first)

--- a/stow-packages/claude/.claude/skills/todoist-cli/SKILL.md
+++ b/stow-packages/claude/.claude/skills/todoist-cli/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: todoist
+description: Manage Todoist tasks, projects, labels, comments, and more via the td CLI
+---
+
+# Todoist CLI (td)
+
+Use this skill when the user wants to interact with their Todoist tasks.
+
+## Quick Reference
+
+- `td today` - Tasks due today and overdue
+- `td inbox` - Inbox tasks
+- `td upcoming` - Tasks due in next N days
+- `td completed` - Recently completed tasks
+- `td auth login` - Authenticate and store the token securely
+- `td task add "content"` - Add a task
+- `td task list` - List tasks with filters
+- `td task complete <ref>` - Complete a task
+- `td project list` - List projects
+- `td label list` - List labels
+- `td filter list/view` - Manage and use saved filters
+- `td workspace list` - List workspaces
+- `td activity` - Activity logs
+- `td notification list` - Notifications
+- `td reminder add` - Task reminders
+- `td auth status` - Authentication status
+- `td stats` - Productivity stats
+- `td settings view` - User settings
+- `td completion install` - Install shell completions
+- `td view <url>` - View supported Todoist entities/pages by URL
+- `td update` - Self-update the CLI to the latest version
+
+## Output Formats
+
+All list commands support:
+- `--json` - JSON output (essential fields)
+- `--ndjson` - Newline-delimited JSON (streaming)
+- `--full` - Include all fields in JSON
+- `--raw` - Disable markdown rendering
+
+## Shared List Options
+
+Most list commands also support:
+- `--limit <n>` - Limit number of results
+- `--all` - Fetch all results (no limit)
+- `--cursor <cursor>` - Continue from pagination cursor
+- `--show-urls` - Show web app URLs for each item
+
+## Global Options
+
+- `--no-spinner` - Disable loading animations
+- `--progress-jsonl` - Machine-readable progress events (JSONL to stderr)
+- `-v, --verbose` - Verbose output to stderr (repeat: -v info, -vv detail, -vvv debug, -vvvv trace)
+- `--accessible` - Add text labels to color-coded output (due:/deadline:/~ prefixes, ★ for favorites). Also: `TD_ACCESSIBLE=1`
+
+## Authentication
+
+```bash
+td auth login                          # OAuth login; stores token in OS credential manager
+td auth token "your-token"            # Save a manual API token
+td auth status                         # Check whether auth works
+td auth logout                         # Remove the saved token
+export TODOIST_API_TOKEN="your-token"  # Highest priority; overrides stored token
+```
+
+If OS credential storage is unavailable, `td` warns and falls back to `~/.config/todoist-cli/config.json`. Legacy plaintext config tokens are migrated automatically when secure storage becomes available.
+
+## References
+
+Tasks, projects, labels, and filters can be referenced by:
+- Name (fuzzy matched within context)
+- `id:xxx` - Explicit ID
+- Todoist URL - Paste directly from the web app (e.g., `https://app.todoist.com/app/task/buy-milk-8Jx4mVr72kPn3QwB` or `https://app.todoist.com/app/project/work-2pN7vKx49mRq6YhT`)
+
+## Priority Mapping
+
+- p1 = Highest priority (API value 4)
+- p2 = High priority (API value 3)
+- p3 = Medium priority (API value 2)
+- p4 = Lowest priority (API value 1, default)
+
+## Commands
+
+### Today
+```bash
+td today                             # Due today + overdue
+td today --json                      # JSON output
+td today --workspace "Work"          # Filter to workspace
+td today --personal                  # Personal projects only
+td today --any-assignee              # Include tasks assigned to others
+```
+
+### Inbox
+```bash
+td inbox                             # Inbox tasks
+td inbox --priority p1               # Filter by priority
+td inbox --due today                 # Filter by due date
+```
+
+### Upcoming
+```bash
+td upcoming                          # Next 7 days
+td upcoming 14                       # Next 14 days
+td upcoming --workspace "Work"       # Filter to workspace
+td upcoming --personal               # Personal projects only
+td upcoming --any-assignee           # Include tasks assigned to others
+```
+
+### Completed
+```bash
+td completed                         # Completed today
+td completed --since 2024-01-01 --until 2024-01-31
+td completed --project "Work"        # Filter by project
+```
+
+### Task Management
+```bash
+# List with filters
+td task list --project "Work"
+td task list --label "urgent" --priority p1
+td task list --due today
+td task list --filter "today | overdue"
+td task list --assignee me
+td task list --assignee "john@example.com"
+td task list --unassigned
+td task list --workspace "Work"
+td task list --personal
+td task list --parent "Parent task"
+
+# View, complete, uncomplete
+td task view "task name"
+td task complete "task name"
+td task complete id:123456
+td task complete "task name" --forever  # Stop recurrence
+td task uncomplete id:123456            # Reopen completed task
+
+# Add tasks
+td task add "New task" --due "tomorrow" --priority p2
+td task add "Task" --deadline "2024-03-01" --project "Work"
+td task add "Task" --duration 1h --section "Planning" --project "Work"
+td task add "Task" --labels "urgent,review" --parent "Parent task"
+td task add "Task" --description "Details here" --assignee me
+
+# Update
+td task update "task name" --due "next week"
+td task update "task name" --deadline "2024-06-01"
+td task update "task name" --no-deadline
+td task update "task name" --duration 2h
+td task update "task name" --assignee "john@example.com"
+td task update "task name" --unassign
+
+# Move
+td task move "task name" --project "Personal"
+td task move "task name" --section "In Progress"
+td task move "task name" --parent "Parent task"
+td task move "task name" --no-parent          # Move to project root
+td task move "task name" --no-section         # Remove from section
+
+# Delete and browse
+td task delete "task name" --yes
+td task browse "task name"                    # Open in browser
+```
+
+### Projects
+```bash
+td project list
+td project list --personal                    # Personal projects only
+td project view "Project Name"
+td project collaborators "Project Name"
+td project create --name "New Project" --color "blue"
+td project update "Project Name" --favorite
+td project archive "Project Name"
+td project unarchive "Project Name"
+td project delete "Project Name" --yes
+td project browse "Project Name"              # Open in browser
+td project move "Project Name" --to-workspace "Acme"
+td project move "Project Name" --to-workspace "Acme" --folder "Engineering"
+td project move "Project Name" --to-workspace "Acme" --visibility team
+td project move "Project Name" --to-personal
+# move requires --yes to confirm (without it, shows a dry-run preview)
+```
+
+### Labels
+```bash
+td label list                                 # Lists personal + shared labels
+td label view "urgent"                        # View label details and tasks
+td label view "team-review"                   # Works for shared labels too
+td label create --name "urgent" --color "red"
+td label update "urgent" --color "orange"
+td label delete "urgent" --yes
+td label browse "urgent"                      # Open in browser
+```
+
+Note: Shared labels (from collaborative projects) appear in `list` and can be viewed, but cannot be deleted/updated via the standard label commands since they have no ID.
+
+### Comments
+```bash
+td comment list --task "task name"
+td comment list --project "Project Name" -P   # Project comments
+td comment add --task "task name" --content "Comment text"
+td comment add --task "task name" --content "See attached" --file ./report.pdf
+td comment view id:123                        # View full comment
+td comment update id:123 --content "Updated text"
+td comment delete id:123 --yes
+td comment browse id:123                      # Open in browser
+```
+
+### Sections
+```bash
+td section list "Work"                        # List sections in project (or --project "Work")
+td section list --project "Work"              # Same, using named flag
+td section create --project "Work" --name "In Progress"
+td section update id:123 --name "Done"
+td section delete id:123 --yes
+td section browse id:123                      # Open in browser
+```
+
+### Filters
+```bash
+td filter list
+td filter create --name "Urgent work" --query "p1 & #Work"
+td filter view "Urgent work"                  # Show tasks matching filter (alias: show)
+td filter update "Urgent work" --query "p1 & #Work & today"
+td filter delete "Urgent work" --yes
+td filter browse "Urgent work"                # Open in browser
+```
+
+### Workspaces
+```bash
+td workspace list
+td workspace view "Workspace Name"
+td workspace projects "Workspace Name"        # or --workspace "Workspace Name"
+td workspace users "Workspace Name" --role ADMIN,MEMBER  # or --workspace "..."
+```
+
+### Activity
+```bash
+td activity                                   # Recent activity
+td activity --since 2024-01-01 --until 2024-01-31
+td activity --type task --event completed
+td activity --project "Work"
+td activity --by me
+td activity --markdown                        # LLM-friendly Markdown output
+```
+
+### Notifications
+```bash
+td notification list
+td notification list --unread
+td notification list --type "item_assign"
+td notification view id:123
+td notification read --all --yes              # Mark all as read
+td notification accept id:123                 # Accept share invitation
+td notification reject id:123                 # Reject share invitation
+```
+
+### Reminders
+```bash
+td reminder list "task name"                  # or --task "task name"
+td reminder add "task name" --before 30m      # or --task "task name" --before 30m
+td reminder add "task name" --at "2024-01-15 10:00"
+td reminder update id:123 --before 1h
+td reminder delete id:123 --yes
+```
+
+### Auth
+```bash
+td auth status                                # Check authentication
+td auth status --json                         # JSON: { id, email, fullName }
+td auth login                                 # OAuth login
+td auth token <token>                         # Save API token
+td auth logout                                # Remove saved token
+```
+
+### Stats
+```bash
+td stats                                      # View karma and productivity
+td stats --json
+td stats goals --daily 10 --weekly 50
+td stats vacation --on                        # Enable vacation mode
+td stats vacation --off                       # Disable vacation mode
+```
+
+### Settings
+```bash
+td settings view
+td settings view --json
+td settings update --timezone "America/New_York"
+td settings update --time-format 24 --date-format intl
+td settings themes                            # List available themes
+```
+
+### Shell Completions
+```bash
+td completion install                         # Install tab completions (prompts for shell)
+td completion install bash                    # Install for specific shell
+td completion install zsh
+td completion install fish
+td completion uninstall                       # Remove completions
+```
+
+### View (URL Router)
+```bash
+td view <todoist-url>                          # Auto-route to appropriate view by URL type
+td view https://app.todoist.com/app/task/buy-milk-abc123
+td view https://app.todoist.com/app/project/work-def456
+td view https://app.todoist.com/app/label/urgent-ghi789
+td view https://app.todoist.com/app/filter/work-tasks-jkl012
+td view https://app.todoist.com/app/today
+td view https://app.todoist.com/app/upcoming
+td view <url> --json                           # JSON output for entity views
+td view <url> --limit 25 --ndjson              # Passthrough list options where supported
+```
+
+### Update
+```bash
+td update                                    # Update CLI to latest version
+td update --check                            # Check for updates without installing
+```
+
+## Examples
+
+### Daily workflow
+```bash
+td today --json | jq '.results | length'      # Count today's tasks
+td inbox --limit 5                             # Quick inbox check
+td upcoming                                    # What's coming this week
+td completed                                   # What I finished today
+```
+
+### Filter by multiple criteria
+```bash
+td task list --project "Work" --label "urgent" --priority p1
+td task list --filter "today & #Work"
+td task list --workspace "Work" --due today
+```
+
+### Complete tasks efficiently
+```bash
+td task complete "Review PR"
+td task complete id:123456789
+td task uncomplete id:123456789                # Reopen if needed
+```

--- a/stow-packages/claude/.claude/skills/what-next/SKILL.md
+++ b/stow-packages/claude/.claude/skills/what-next/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: what-next
+description: This skill should be used when the user asks "what next", "what-next", "what should I work on", "what's next", or otherwise wants a recommendation for the next piece of work to pick up. Synthesizes across active projects, project logs, the wiki log, and today's daily note to surface a single recommended task plus a triage view of overdue work, open follow-ups, and stale projects.
+version: 0.1.0
+allowed-tools:
+  [
+    Bash,
+    Read,
+    Glob,
+    mcp__plugin_fbg-core_atlassian__getJiraIssue,
+    mcp__plugin_fbg-core_atlassian__searchJiraIssuesUsingJql,
+    mcp__plugin_fbg-core_atlassian__getJiraIssueRemoteIssueLinks,
+  ]
+---
+
+# What-Next Skill
+
+Advisory skill that answers the question **"What should I work on next?"** by reading three sources and synthesizing a recommendation in narrative form. Read-only and terminal-only — no file writes, no daily note mutation. Live JIRA status and GitHub PR status are verified for any candidate before it's recommended, to avoid suggesting work that has already been closed, merged, or moved since `/start-of-day` last refreshed the daily note. Cheap to run multiple times a day.
+
+## Purpose
+
+Between explicit start-of-day and end-of-day routines the user often needs a quick re-orientation: returning from a meeting, finishing a task with no obvious next step, starting an afternoon block, or just losing the thread. Today's daily note (populated by `/start-of-day`) holds open PRs and JIRA. The vault's `projects/` directory holds active project state. The wiki's `_log.md` holds recent compile activity. This skill pulls those three signals together and recommends one concrete next move, with a short triage view underneath.
+
+The skill is one-shot and non-interactive: read, reason, print, done.
+
+## When to Use
+
+- User explicitly runs `/what-next`
+- User asks "what next", "what's next", "what should I work on", "what should I do next"
+- User says they're stuck, between tasks, or coming back from a break with no clear next step
+
+## When NOT to Use
+
+- Start of day — run `/start-of-day` instead (it populates today's daily note that *this* skill consumes)
+- End of day — run `/end-of-day` instead
+- Standup prep — run `/daily-standup`
+- User already has a specific JIRA ticket in mind — use `/start-ticket`
+
+## Pipeline
+
+```
+  Read (parallel)         →   LLM synthesizes recommendation   →   Print to terminal
+  - today's daily note        - single pick + reasoning            (no file writes)
+  - projects index +          - themed sections grouped
+    each active project's       by urgency
+    README.md and log.md
+  - wiki/_log.md tail
+```
+
+## Prerequisites
+
+- `/start-of-day` should ideally have been run today so the daily note is populated. If it hasn't, the skill notes that and continues with the other two sources.
+- `obsidian` CLI available for resolving the daily note path. If absent, fall back to constructing the path from `date`.
+
+## Process Flow
+
+### Step 1: Resolve today's daily note path
+
+```bash
+DAILY_NOTE_PATH="$(obsidian daily:path 2>/dev/null)" || \
+  DAILY_NOTE_PATH="$HOME/Documents/Work/raw/daily_notes/$(date +%Y/%m/%Y-%m-%d-%A).md"
+```
+
+If the file doesn't exist, find the most recent daily note as a fallback and remember its age:
+
+```bash
+test -f "$DAILY_NOTE_PATH" || \
+  DAILY_NOTE_PATH="$(ls -t $HOME/Documents/Work/raw/daily_notes/*/*/*.md | head -1)"
+```
+
+Record whether today's note exists. If it doesn't, the final output must flag the staleness ("Daily note is N days old — recommendation may miss recent JIRA/PR activity.").
+
+### Step 2: Read all sources in parallel
+
+Issue these Read tool uses in a single assistant message so they execute concurrently:
+
+1. **Today's daily note** (path from Step 1). Extract:
+   - Overdue / today Todoist items
+   - Any manual sections the user added outside the `<!-- sod:begin/end -->` markers (Plan, Blockers, Done — these are high-signal)
+   - PR cross-link hints: lines like `· PRs: [#N](url)` on JIRA rows. Useful as a starting set of repos/numbers, but treat as advisory — the authoritative JIRA list comes from the live JQL fetch below, not the daily note. The note's JIRA snapshot may be hours stale; **always prefer the fresh JQL result** when the two disagree.
+2. **Live assigned JIRA tickets** — call `mcp__plugin_fbg-core_atlassian__searchJiraIssuesUsingJql` with JQL like:
+
+   ```
+   assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC
+   ```
+
+   This catches tickets added or re-assigned throughout the day that won't be in today's daily note. Capture each result's key, status, summary, priority, and updated timestamp. This list — not the daily note — is the source of truth for "what JIRA work is on my plate right now."
+3. **Projects index** — `~/Documents/Work/projects/_projects-index.md`. Enumerate the **Active** section.
+4. **Wiki log tail** — `~/Documents/Work/wiki/_log.md`. Read the last ~80 lines. Look for recent compile entries with unresolved follow-ups, `Step failures`, or themes that keep recurring.
+
+### Step 3: For each active project, read its state
+
+Issue Read calls for both files of each active project in parallel:
+
+- `~/Documents/Work/projects/<name>/README.md` — pull `due_date`, `next_action`, `status`, and any unchecked success-criteria checkboxes.
+- `~/Documents/Work/projects/<name>/log.md` — focus on the top ~80 lines (newest entries are first). Look for unfinished sub-tasks, "follow-up", "TODO", "blocked on", "awaiting", or in-progress markers.
+
+### Step 4: Synthesize
+
+Apply these heuristics in narrative form. **No numeric scoring** — read between the lines.
+
+- **Overdue / due soon** — projects whose `due_date` is past or within 7 days of today.
+- **Open follow-ups from recent work** — items mentioned in the last few daily-note sections / project logs / wiki log entries that don't have a "Done", "Closed", or "Merged" marker.
+- **Stale projects worth touching** — Active projects whose `log.md` hasn't been updated in 14+ days.
+- **In-progress JIRA** — from the fresh JQL fetch in Step 2. A ticket with status `In Progress` / `In Review` and no matching recent activity in any log is a strong signal — it's been forgotten.
+- **Ready to close — work shipped, ticket still open** — JIRA tickets from the fresh JQL fetch whose linked PRs are all MERGED (no still-open PR pointing at the same key). Detected via the live cross-check in Step 5 (see below); the LLM should treat any candidate carrying this signal as a top-priority quick-win, since closing it is a 30-second status transition that clears the board. Don't rely on the daily note's `🟢 Potential to close` marker — recompute from live JIRA + PR state because tickets get added/moved throughout the day.
+
+When picking the top recommendation:
+
+- Prefer items that show up in **two or more** of the buckets above.
+- If "Ready to close" candidates exist and nothing is strictly overdue or actively blocked, lead with one of them. Phrasing: "Close FANDEVX-2920 — PR #2227 merged on 2026-05-17 and the ticket is still In Progress. 30-second admin win, then move on to …"
+
+### Step 5: Verify live status before recommending
+
+Before printing, verify the live status of any JIRA ticket or GitHub PR you plan to name in the recommendation. The daily note can be hours stale; recommending work on a ticket that has moved to Done or a PR that has merged or been closed wastes the user's time.
+
+**Only verify the candidates named in the output** — the top pick plus any runner-up mentioned in the lead paragraph. Typically 1–3 verification calls. The triage sections below the recommendation can quote the daily note's snapshot without re-verifying. Issue all verification calls in parallel (single assistant message, multiple tool uses).
+
+**JIRA ticket verification** — if the candidate references a key like `FANDEVX-1234`, `FESFEAT-5678`, or any `[A-Z]+-\d+` pattern:
+
+- Call `mcp__plugin_fbg-core_atlassian__getJiraIssue` with the key.
+- If status is **Done / Closed / Cancelled / Won't Do**, drop and pick the next candidate. Mention what changed ("FANDEVX-2920 is actually Done as of this morning — moving on to …").
+- If **re-assigned to someone else**, drop and pick the next candidate.
+- If genuinely still open (In Progress / In Review / To Do), include the **live** status in the reasoning.
+- **Ready-to-close cross-check** — call `mcp__plugin_fbg-core_atlassian__getJiraIssueRemoteIssueLinks` to list the ticket's linked PRs. For each linked PR URL, run `gh pr view` (per the GitHub PR verification block below) to get its `state`. If the ticket is still open but **every** linked PR is `MERGED` (and there is at least one), flag this candidate as **ready to close** and lead the recommendation with "Close <KEY> — work shipped". If `getJiraIssueRemoteIssueLinks` returns no PR links, fall back to scanning the ticket description / comments returned by `getJiraIssue` for `github.com/.../pull/\d+` URLs.
+
+**GitHub PR verification** — if the candidate is a PR (URL like `github.com/<owner>/<repo>/pull/<n>` or `#<n>` cited from the daily note's Open Pull Requests section):
+
+- Ensure the correct identity is active: `gh auth switch --user ian-at-fes` (for any `fanatics-gaming` org repo). Then fetch with:
+
+  ```bash
+  gh pr view <number> --repo <owner>/<repo> \
+    --json state,isDraft,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,updatedAt,headRefName
+  ```
+
+- If `state` is **MERGED** or **CLOSED**, drop and pick the next candidate. Mention what changed ("PR #2227 already merged — the recommendation is now the follow-up on …").
+- If `isDraft` is true, keep it as a candidate only if the action is "finish the draft"; otherwise prefer a non-draft PR or another candidate.
+- If `reviewDecision` is **APPROVED** and `mergeable` is **MERGEABLE** with all checks green (`statusCheckRollup` all SUCCESS) → the recommendation should be "merge this PR" not "keep working on it."
+- If `reviewDecision` is **CHANGES_REQUESTED**, the recommendation should be "address review feedback on PR #N."
+- If `statusCheckRollup` shows FAILURE / PENDING for blocking checks, surface that in the reasoning ("CI failing on PR #N — fix that before moving on").
+
+If the MCP/gh call fails (network, auth, transient), continue with the daily-note snapshot but add a one-line caveat in the Quick context section ("JIRA/PR status check failed — recommendation based on daily-note snapshot only.").
+
+If the recommendation is **not** a JIRA ticket or PR (e.g. "finish the team-proposal.md draft", "compile the open follow-ups from yesterday's wiki log"), skip this step entirely.
+
+### Step 6: Print the recommendation
+
+Output goes to the terminal only — no file writes. Use this format:
+
+```markdown
+## Recommended next: <single clear pick>
+
+<2–3 sentences explaining why — cite the specific signal: due date, in-progress ticket, follow-up note, log entry. Mention a runner-up in the last sentence if there's a close second.>
+
+---
+
+### Ready to close — work shipped, ticket still open
+- **[KEY](url)** — <title> · PR <#N> merged <date> · suggest transition to Done
+
+### Overdue / Due Soon
+- **<Project>** — due <date> · <one-line state>
+
+### Open Follow-ups
+- **<Project or wiki entry>** — <follow-up description> (from <source>, <date>)
+
+### Stale — worth touching
+- **<Project>** — last log entry <date> (<N days ago>)
+
+### Quick context
+- Daily note: <fresh / N days stale / missing>
+- Active projects: <count>
+- Open PRs in daily note: <count>
+- In-progress JIRA tickets: <count>
+```
+
+**Omit any section that has no items** — don't print empty headers. If there's nothing urgent at all, say so plainly ("Nothing overdue, no open follow-ups surfaced. Suggested pick is the project with the most open success-criteria items: …").
+
+## Error Handling
+
+- **Daily note missing entirely (no fallback found):** proceed with only `projects/` + `wiki/_log.md`. Note the absence in the Quick context section.
+- **`obsidian` CLI absent:** silently fall back to the manually-constructed path; do not error.
+- **Projects index missing or empty Active section:** print a single line ("No active projects in `_projects-index.md`.") and emit only the wiki / daily-note view.
+- **Empty wiki log tail:** skip wiki-derived follow-ups, continue.
+
+Never write to disk. Never modify the daily note. Live calls allowed: `searchJiraIssuesUsingJql` (once, in Step 2, for assigned-open tickets), `getJiraIssue` and `getJiraIssueRemoteIssueLinks` (Step 5, only for candidates being recommended), and `gh pr view` (Step 5, only for PRs being recommended or linked from a recommended ticket). No live Todoist calls — those come from the daily note.
+
+## Related Skills
+
+- `/start-of-day` — populates today's daily note (open PRs, JIRA, Todoist). Run this first if it hasn't been today.
+- `/daily-standup` — formal standup prep with blocker prompts.
+- `/end-of-day` — closes out the day and flushes to the wiki log.
+- `/start-ticket` — kick off work on a specific JIRA ticket (use after `/what-next` if the recommendation is a ticket).


### PR DESCRIPTION
## Summary

- New `claude` stow package mirroring the existing per-tool convention — brings `~/.claude/CLAUDE.md` and 11 user-level skills under version control.
- README and `.gitignore` updated. The `.gitignore` negation is required because the global `~/.gitignore` excludes `.claude/` everywhere, which silently swallows the package contents until overridden in-repo.
- `render.py` files in `daily-standup/` and `start-of-day/` keep their executable bit (committed as mode 100755).

## Test plan

- [x] `stow -v -t "$HOME" --ignore="\.DS_Store" claude` — links all 12 entries with no conflicts
- [x] `readlink ~/.claude/CLAUDE.md` and `readlink ~/.claude/skills/<name>` resolve into the repo
- [x] `~/.claude/CLAUDE.md` and `~/.claude/skills/` byte-match a pre-move backup
- [x] Re-running stow is idempotent (no LINK output on second run)
- [x] `~/.claude/sessions/`, `plans/`, `plugins/`, `settings.json`, `history.jsonl` remain real (not symlinked)
- [x] Skills load in a new Claude Code session (`/daily-standup`, `/rfc`, etc. visible in the registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)