### PR TITLE
end-of-day: unattended mode for scheduled runs

### DIFF
--- a/docs/superpowers/plans/2026-06-17-end-of-day-unattended.md
+++ b/docs/superpowers/plans/2026-06-17-end-of-day-unattended.md
@@ -1,0 +1,748 @@
+# End-of-Day Unattended Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/end-of-day` run unsupervised as a local Claude Code Desktop scheduled task with zero permission prompts and zero in-skill gates, auto-creating meeting-action-item todos that are deduped against the live Todoist list without ever silently burying a real commitment.
+
+**Architecture:** Three independent workstreams. (A) A deterministic dedup backstop added to `meeting_action_items.py` in the `lyt-assistant` repo, protecting every caller. (B) An `--unattended` mode added to the `end-of-day` SKILL.md prompt in the `.dotfiles` repo, which removes interactive gates, keeps external writes draft/dry-run, auto-writes only the local daily note, and ends with a push notification. (C) A start-of-day dead-man's-switch check + local machine setup (settings allow/deny, scheduled-task body, plist removal) gated behind two clean scheduled runs.
+
+**Tech Stack:** Python 3 stdlib (no deps), Claude Code skills (markdown prompts), `td` Todoist CLI, macOS `launchctl`, Claude Code Desktop scheduled tasks.
+
+## Global Constraints
+
+- `meeting_action_items.py` stays **Python 3 stdlib only** — no new dependencies. (verbatim from spec)
+- Dedup match rule is **normalized-equality OR token-set overlap ≥ 0.85**, NEVER substring containment. (verbatim from spec)
+- A live-todo dedup match is **non-terminal**: not created this run, not recorded in state, re-evaluated next run. (verbatim from spec)
+- The dedup backstop is **best-effort**: any `td` failure yields an empty existing-titles list and dedup is skipped, never a hard error.
+- `--unattended` must make **no `AskUserQuestion` calls** and **no continue/retry/halt prompts**; Step 0 pre-flight is the one hard halt.
+- External/published writes (Confluence) are **draft/dry-run only** unattended; the local daily note is the one auto-write.
+- No emojis and no em dashes in any saved/shared text (commits, file contents). (user CLAUDE.md)
+- Do NOT delete the EOD LaunchAgent until **2 consecutive clean scheduled runs** are observed.
+- Tests run as a plain script: `python3 test_meeting_action_items.py` (no pytest).
+
+## File Structure
+
+- `lyt-assistant` repo (`~/.claude/plugins/marketplaces/ian-bartholomew-lyt-assistant/`):
+  - `skills/meeting-action-items/meeting_action_items.py` — MODIFY: add dedup functions + wire into `cmd_apply`.
+  - `skills/meeting-action-items/test_meeting_action_items.py` — MODIFY: add dedup tests.
+  - `skills/meeting-action-items/SKILL.md` — MODIFY: document the `duplicate` outcome + skip-not-dismiss rule for the model layer.
+- `.dotfiles` repo (current worktree):
+  - `stow-packages/claude/.claude/skills/end-of-day/SKILL.md` — MODIFY: frontmatter + Unattended Mode section.
+  - `stow-packages/claude/.claude/skills/start-of-day/SKILL.md` — MODIFY: dead-man's-switch check.
+- Local machine (not version-controlled):
+  - `~/.claude/settings.json` — allow/deny edits.
+  - `~/.claude/scheduled-tasks/end-of-day/SKILL.md` — task body → `/end-of-day --unattended`.
+  - `~/Library/LaunchAgents/com.ian.{eod,sod,standup}.plist` — backup + remove.
+
+---
+
+## Workstream A — Todoist dedup backstop (lyt-assistant repo)
+
+> All Task A steps run in the `lyt-assistant` repo. Create a branch first:
+> `cd ~/.claude/plugins/marketplaces/ian-bartholomew-lyt-assistant && git checkout -b end-of-day-dedup-backstop`
+> Paths below are relative to that repo root.
+
+### Task A1: Pure dedup functions
+
+**Files:**
+
+- Modify: `skills/meeting-action-items/meeting_action_items.py`
+- Test: `skills/meeting-action-items/test_meeting_action_items.py`
+
+**Interfaces:**
+
+- Produces: `dedup_normalize(s: str) -> str`, `dedup_tokens(s: str) -> set`, `title_similarity(a: str, b: str) -> float`, `find_duplicate(candidate: str, existing: list[str]) -> str | None`, module constant `DEDUP_THRESHOLD = 0.85`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test_meeting_action_items.py` (before the `if __name__` block):
+
+```python
+def test_dedup_normalize():
+    assert mai.dedup_normalize("- [ ] Email Bob!") == "email bob"
+    assert mai.dedup_normalize("Email   Bob.") == "email bob"
+    assert mai.dedup_normalize("Review PR #1842 (urgent)") == "review pr 1842 urgent"
+    # NFKC fold + emoji/punct become separators, not retained
+    assert mai.dedup_normalize("Ship — the 🚀 release") == "ship the release"
+
+
+def test_title_similarity():
+    assert mai.title_similarity("Email Bob", "email bob.") == 1.0
+    # distinct short title must NOT merge into a longer one (data-loss guard)
+    assert mai.title_similarity(
+        "Email Bob", "Email Bob about the Q3 contract") < mai.DEDUP_THRESHOLD
+    # reworded-but-same significant tokens scores high
+    assert mai.title_similarity(
+        "follow up with Dave on kafka rollout",
+        "follow up with Dave on the kafka rollout") >= mai.DEDUP_THRESHOLD
+
+
+def test_find_duplicate():
+    existing = ["Email Bob about the Q3 contract", "Review the deploy runbook"]
+    # normalized-equality match
+    assert mai.find_duplicate("review the deploy runbook!", existing) == \
+        "Review the deploy runbook"
+    # distinct short title is NOT a duplicate (would have been with substring)
+    assert mai.find_duplicate("Email Bob", existing) is None
+    # nothing matches
+    assert mai.find_duplicate("Write the design doc", existing) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd skills/meeting-action-items && python3 -c "import test_meeting_action_items as t; t.test_dedup_normalize()"`
+Expected: FAIL with `AttributeError: module 'meeting_action_items' has no attribute 'dedup_normalize'`
+
+- [ ] **Step 3: Add `import unicodedata`**
+
+In `meeting_action_items.py`, add to the import block (after `import tempfile`):
+
+```python
+import unicodedata
+```
+
+- [ ] **Step 4: Implement the dedup functions**
+
+In `meeting_action_items.py`, add after the `normalize()` / `key_for()` block (after line ~59, before `body_of`):
+
+```python
+DEDUP_THRESHOLD = 0.85
+DEDUP_STOPWORDS = {
+    "the", "a", "an", "to", "of", "for", "and", "with",
+    "on", "in", "re", "about", "please",
+}
+
+
+def dedup_normalize(s: str) -> str:
+    """Aggressive normalization for cross-todo dedup. Distinct from
+    normalize() (which mirrors the legacy state-key bash chain): NFKC fold,
+    strip a leading bullet/checkbox, lowercase, replace every non-word char
+    with a space, collapse whitespace."""
+    s = unicodedata.normalize("NFKC", s)
+    s = BULLET_RE.sub("", s)
+    s = s.lower()
+    s = re.sub(r"[^\w\s]", " ", s, flags=re.UNICODE)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def dedup_tokens(s: str) -> set:
+    return {t for t in dedup_normalize(s).split() if t not in DEDUP_STOPWORDS}
+
+
+def title_similarity(a: str, b: str) -> float:
+    """Jaccard over significant tokens. 1.0 == identical significant-token
+    sets. Substring containment deliberately does NOT score high."""
+    ta, tb = dedup_tokens(a), dedup_tokens(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def find_duplicate(candidate: str, existing: list[str]) -> str | None:
+    """First existing title that is a normalized-equal or high-token-overlap
+    match for candidate, else None. Never uses substring containment."""
+    cnorm = dedup_normalize(candidate)
+    if cnorm:
+        for e in existing:
+            if dedup_normalize(e) == cnorm:
+                return e
+    for e in existing:
+        if title_similarity(candidate, e) >= DEDUP_THRESHOLD:
+            return e
+    return None
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd skills/meeting-action-items && python3 test_meeting_action_items.py`
+Expected: all tests PASS, including the three new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/meeting-action-items/meeting_action_items.py skills/meeting-action-items/test_meeting_action_items.py
+git commit -m "feat(meeting-action-items): add token-set dedup primitives"
+```
+
+### Task A2: Wire dedup into `apply`
+
+**Files:**
+
+- Modify: `skills/meeting-action-items/meeting_action_items.py`
+- Test: `skills/meeting-action-items/test_meeting_action_items.py`
+
+**Interfaces:**
+
+- Consumes: `find_duplicate`, `DEDUP_THRESHOLD` (Task A1).
+- Produces: `fetch_open_titles(dry_run: bool) -> list[str]`; `apply` accepts `--existing-todos <path>` (JSON list of titles, test hook); a new `duplicate` outcome in results carrying `matched`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test_meeting_action_items.py`:
+
+```python
+def test_apply_dedup_skips_existing():
+    import shutil
+    with tempfile.TemporaryDirectory() as td_dir:
+        vault = Path(td_dir) / "vault"
+        shutil.copytree(HERE / "test-fixtures" / "vault", vault)
+        existing = Path(td_dir) / "existing.json"
+        existing.write_text(json.dumps(["Send the quarterly report by Friday"]))
+        payload = {"auto_checked": [], "decisions": [
+            {"key": "dup1", "meeting_dir": "2026-06-01-standup",
+             "raw": "- [ ] Send the quarterly report by Friday",
+             "action": "todo", "title": "Send the quarterly report by Friday",
+             "description": "d", "due": "Friday", "priority": "p2"}]}
+        out = subprocess.run(
+            [sys.executable, str(HERE / "meeting_action_items.py"),
+             "--vault", str(vault), "apply", "--dry-run",
+             "--existing-todos", str(existing)],
+            input=json.dumps(payload), capture_output=True, text=True)
+        assert out.returncode == 0, out.stderr
+        res = json.loads(out.stdout)["results"][0]
+        assert res["outcome"] == "duplicate"
+        assert res["matched"] == "Send the quarterly report by Friday"
+        state = json.loads(
+            (vault / ".lyt-assistant" / "_action-item-state.json").read_text())
+        assert "dup1" not in state["items"]          # non-terminal: not recorded
+        assert state["last_run"] is not None          # run still completes
+
+
+def test_apply_dedup_distinct_short_title_not_skipped():
+    import shutil
+    with tempfile.TemporaryDirectory() as td_dir:
+        vault = Path(td_dir) / "vault"
+        shutil.copytree(HERE / "test-fixtures" / "vault", vault)
+        existing = Path(td_dir) / "existing.json"
+        existing.write_text(json.dumps(["Email Bob about the Q3 contract"]))
+        payload = {"auto_checked": [], "decisions": [
+            {"key": "short1", "meeting_dir": "2026-06-01-standup",
+             "raw": "- [ ] Email Bob", "action": "todo", "title": "Email Bob",
+             "description": "d", "due": "", "priority": "p2"}]}
+        out = subprocess.run(
+            [sys.executable, str(HERE / "meeting_action_items.py"),
+             "--vault", str(vault), "apply", "--dry-run",
+             "--existing-todos", str(existing)],
+            input=json.dumps(payload), capture_output=True, text=True)
+        assert out.returncode == 0, out.stderr
+        assert json.loads(out.stdout)["results"][0]["outcome"] == "created"
+
+
+def test_apply_dedup_batch_self():
+    import shutil
+    with tempfile.TemporaryDirectory() as td_dir:
+        vault = Path(td_dir) / "vault"
+        shutil.copytree(HERE / "test-fixtures" / "vault", vault)
+        existing = Path(td_dir) / "existing.json"
+        existing.write_text(json.dumps([]))     # nothing pre-existing
+        payload = {"auto_checked": [], "decisions": [
+            {"key": "a", "meeting_dir": "2026-06-01-standup", "raw": "- [ ] x",
+             "action": "todo", "title": "Draft the launch checklist",
+             "description": "d", "due": "", "priority": "p2"},
+            {"key": "b", "meeting_dir": "2026-06-01-standup", "raw": "- [ ] y",
+             "action": "todo", "title": "draft the launch checklist!",
+             "description": "d", "due": "", "priority": "p2"}]}
+        out = subprocess.run(
+            [sys.executable, str(HERE / "meeting_action_items.py"),
+             "--vault", str(vault), "apply", "--dry-run",
+             "--existing-todos", str(existing)],
+            input=json.dumps(payload), capture_output=True, text=True)
+        assert out.returncode == 0, out.stderr
+        res = {r["key"]: r["outcome"] for r in json.loads(out.stdout)["results"]}
+        assert res["a"] == "created"
+        assert res["b"] == "duplicate"      # matched the just-created sibling
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd skills/meeting-action-items && python3 test_meeting_action_items.py`
+Expected: FAIL — `--existing-todos` is an unrecognized argument / `duplicate` outcome not produced.
+
+- [ ] **Step 3: Add `fetch_open_titles` and the `--existing-todos` arg**
+
+In `meeting_action_items.py`, add after `td_add()` (before `cmd_apply`):
+
+```python
+def fetch_open_titles(dry_run: bool) -> list[str]:
+    """Open Work-project task titles via td. Empty list on ANY failure:
+    dedup is a best-effort backstop, never a hard dependency. Uses --all to
+    page past the 300-task default."""
+    if dry_run:
+        return []
+    try:
+        r = subprocess.run(
+            ["td", "task", "list", "--project", "Work", "--all", "--json"],
+            capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        return []
+    if r.returncode != 0:
+        return []
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return []
+    results = data.get("results", []) if isinstance(data, dict) else data
+    return [t.get("content", "") for t in results
+            if isinstance(t, dict) and t.get("content")]
+```
+
+In `main()`, add the arg to the `apply` parser (after the `--dry-run` line):
+
+```python
+    pa.add_argument("--existing-todos")
+```
+
+- [ ] **Step 4: Load existing titles in `cmd_apply` and dedup in the todo branch**
+
+In `cmd_apply`, after the `td auth status` check block and before `results = []`, add:
+
+```python
+    if args.existing_todos:
+        with open(args.existing_todos) as f:
+            existing_titles = list(json.load(f))
+    else:
+        existing_titles = fetch_open_titles(args.dry_run)
+```
+
+Then replace the `if action == "todo":` block body so it dedups first:
+
+```python
+            if action == "todo":
+                matched = find_duplicate(d["title"], existing_titles)
+                if matched is not None:
+                    # non-terminal: skip creation, do NOT record state, so it
+                    # resurfaces if the matched live todo is later completed.
+                    results.append({"key": d["key"], "outcome": "duplicate",
+                                    "matched": matched})
+                    continue
+                ok, info = td_add(d["title"], d.get("priority", "p2"),
+                                  d["description"], d.get("due", ""),
+                                  args.dry_run)
+                if ok:
+                    record(d["key"], d["meeting_dir"], d["raw"],
+                           "todoed", info)
+                    existing_titles.append(d["title"])  # dedup later batch items
+                    results.append({"key": d["key"], "outcome": "created",
+                                    "url": info})
+                else:
+                    results.append({"key": d["key"], "outcome": "failed",
+                                    "error": info})
+                continue
+```
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cd skills/meeting-action-items && python3 test_meeting_action_items.py`
+Expected: all PASS, including the three new dedup-apply tests and the pre-existing `test_apply_dry_run` / `test_apply_failing_td` / `test_apply_malformed_decision`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/meeting-action-items/meeting_action_items.py skills/meeting-action-items/test_meeting_action_items.py
+git commit -m "feat(meeting-action-items): dedup new todos against live Work project"
+```
+
+### Task A3: Document the dedup contract in the skill
+
+**Files:**
+
+- Modify: `skills/meeting-action-items/SKILL.md`
+
+**Interfaces:**
+
+- Consumes: the `duplicate` outcome + non-terminal rule (Task A2). No code.
+
+- [ ] **Step 1: Add a Dedup subsection**
+
+In `skills/meeting-action-items/SKILL.md`, in the `### Step 4: Apply` section, after the sentence describing `apply` outputs, append:
+
+```markdown
+`apply` also dedups every `todo` against the live Todoist Work project
+(`td task list --project Work --all --json`) before creating it. A candidate
+whose title is a normalized-equal or high-token-overlap (>= 0.85) match for an
+existing open task returns outcome `duplicate` (with the matched title) and is
+**not created and not recorded in state** — so it resurfaces next run if the
+matched live todo is later completed. Substring containment is never used, so a
+short title ("Email Bob") is not swallowed by a longer one ("Email Bob about
+the Q3 contract"). Callers driving non-interactive runs MUST mark a
+model-detected semantic duplicate as `skip` (non-terminal), never `dismiss`
+(terminal) — permanent suppression of an action item is reserved for an
+explicit user decision.
+```
+
+- [ ] **Step 2: Bump the skill version**
+
+In the frontmatter, bump `version:` by a patch (e.g. `0.8.0` -> `0.9.0`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/meeting-action-items/SKILL.md
+git commit -m "docs(meeting-action-items): document live-Todoist dedup contract"
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin end-of-day-dedup-backstop
+gh pr create --title "meeting-action-items: dedup new todos against live Todoist" --body "Adds a deterministic, best-effort dedup backstop in apply: normalized-equality or token-set overlap >= 0.85 (never substring containment), non-terminal duplicate state so commitments resurface if the matched todo is completed. Tests cover the match rule, normalization vectors, batch self-match, and the short-title data-loss guard."
+```
+
+---
+
+## Workstream B — `--unattended` mode (.dotfiles, current worktree)
+
+### Task B1: end-of-day `--unattended` mode
+
+**Files:**
+
+- Modify: `stow-packages/claude/.claude/skills/end-of-day/SKILL.md`
+
+**Interfaces:**
+
+- Consumes: the `meeting_action_items.py` `duplicate` outcome and the model `skip`-not-`dismiss` rule (Workstream A).
+
+- [ ] **Step 1: Frontmatter — argument hint + PushNotification tool**
+
+In the SKILL.md frontmatter: add an `argument-hint`, and add `PushNotification` to `allowed-tools`.
+
+Change:
+
+```yaml
+version: 0.3.0
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent, TaskStop]
+```
+
+to:
+
+```yaml
+version: 0.4.0
+argument-hint: "[--unattended]"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent, TaskStop, PushNotification]
+```
+
+- [ ] **Step 2: Add the Unattended Mode section**
+
+Insert a new `## Unattended Mode` section immediately before `## Pipeline Overview`:
+
+````markdown
+## Unattended Mode
+
+When invoked as `/end-of-day --unattended` (the scheduled Desktop task uses
+this), the pipeline runs with no human present. Manual `/end-of-day` is
+unchanged. Both modes share every step body; they differ ONLY at the points
+listed here. If the `--unattended` token is absent, ignore this entire section.
+
+### Global rules (unattended)
+
+- **No `AskUserQuestion` calls. No continue/retry/halt prompts.** Every place
+  the interactive flow would ask, take the documented auto-default and continue.
+- **Best-effort.** A mid-run sub-skill failure is logged to the report and the
+  run continues. The single exception is Step 0 pre-flight, which still HALTS.
+- **External/published writes are draft/dry-run only** (see Step 2). The local
+  daily note (Step 9) is the one surface auto-written, because it is local,
+  reversible, and idempotently upserted.
+- **End every run with a notification** (Observability, below).
+
+### Concurrency lock (first action, unattended)
+
+Before Step 0, acquire an exclusive lock so a catch-up run and a manual run
+cannot double-write the shared `/tmp` caches and `_action-item-state.json`:
+
+```bash
+if ! mkdir /tmp/eod.lock 2>/dev/null; then
+  echo "end-of-day already running (/tmp/eod.lock present); aborting."; exit 0
+fi
+```
+
+Remove `/tmp/eod.lock` (`rmdir /tmp/eod.lock`) as the final action of the run,
+including on any failure path that ends the run early.
+
+### Run-date under catch-up
+
+A Desktop task missed because the Mac was asleep fires a single catch-up within
+7 days. The cached `date +%Y-%m-%d` therefore reflects the **actual run day**,
+not the missed day. All source steps are "since last run", so nothing is lost;
+the daily-note section and report are labeled with the run day. This is expected
+behavior, not an error.
+
+### Per-step deltas (unattended)
+
+- **Step 0 (pre-flight):** unchanged; still HALTS on failure. On halt, send the
+  failure notification and release the lock before exiting.
+- **Step 2 (FES support -> Confluence):** the background subagent must run
+  **draft/hold only** -- do NOT publish a live Confluence page. Instruct it: if
+  the fes-support-learnings skill supports draft pages, publish as DRAFT;
+  otherwise write the would-be page content to
+  `raw/support_learnings/_pending_confluence/<date>.md` and report it as
+  deferred. Live Confluence publish is for interactive runs.
+- **Steps 3, 4 (support / internal -> raw/):** run non-interactively using the
+  exact auto-default convention Step 2 already documents (classification ->
+  `knowledge`, resolution -> `unresolved`, domain -> keyword-map else
+  `general`, duplicate -> `skip`, any other -> the skip/no-action option).
+  Record every auto-default for the report. (These write to local `raw/`, which
+  is reviewable and compiled later, so auto-defaulting is acceptable.)
+- **Step 5 (meeting action items):** run inline, no AskUserQuestion:
+  1. `python3 <skill-dir>/meeting_action_items.py list` -> candidates with
+     suggested title/due/priority.
+  2. `td task list --project Work --all --json` -> existing open todos.
+  3. Semantic pass: for each candidate that MEANS THE SAME as an existing open
+     todo (reworded duplicate the string layer would miss), mark it `skip`
+     (NON-terminal -- never `dismiss`). Only skip on high confidence; when
+     unsure, let it through as a `todo` (a near-dupe is recoverable; a dropped
+     commitment is not). Log each skip with the matched todo title.
+  4. Build the decisions JSON: surviving candidates -> `todo` with the script's
+     suggested due/priority; semantic dupes -> `skip`.
+  5. `python3 <skill-dir>/meeting_action_items.py apply --input <file>`. The
+     script independently dedups each `todo` against the live Work project and
+     returns `duplicate` (non-terminal) for any it catches -- this is the
+     deterministic backstop beneath the semantic pass.
+  Report created vs `skip` (semantic dupe) vs `duplicate` (script backstop);
+  never silently drop. (`<skill-dir>` is the meeting-action-items skill dir
+  announced when that skill loads.)
+- **Step 6 (project-log gate):** run the audit (detection) ONLY. Do NOT
+  auto-write `log.md` entries. Record each gap in the report and add it to the
+  Step 9 daily-note Follow-ups for the next interactive session.
+- **Step 7 (compile):** run non-interactively. (If the compile sub-skill exposes
+  any prompt, take its default.)
+- **Step 9 (daily-note synthesis):** auto-approve and write the drafted section.
+  The upsert and `grep -c '<!-- eod:begin'` post-write check are unchanged. If
+  the check returns `0` or `>1`, do NOT proceed silently: record a failure
+  marker and include it in the notification.
+- **Step 10 (report):** after writing the `wiki/_log.md` entry, send the
+  end-of-run notification (below), then release the lock.
+
+### Observability (unattended)
+
+- **End-of-run notification.** Send a `PushNotification` with a one-line status:
+  `end-of-day <date>: ok` / `end-of-day <date>: degraded (<N> step failures)` /
+  `end-of-day <date>: halted (pre-flight)`. Include the deduped/deferred counts
+  and any step failures in the body.
+- **Permission self-check.** If any tool call in the run was blocked or timed
+  out waiting on a permission decision (the symptom of the Desktop
+  `bypassPermissions` mode having silently reverted), treat the run as
+  `degraded` and say so in the notification -- this is how a reverted permission
+  mode gets surfaced instead of discovered later.
+
+### Success checklist (what "ran cleanly" means)
+
+A clean unattended run satisfies all of: pre-flight passed; Slack steps 2/3/4
+reached and produced output or an honest nothing-to-do; Confluence stayed
+draft/deferred; Step 5 reported created vs skip vs duplicate with no silent
+drop; the daily-note section was written and the post-write check returned
+exactly 1; the notification status is `ok`; and `wiki/_log.md` has the run entry
+for the resolved date.
+````
+
+- [ ] **Step 3: Cross-reference the dedup in Step 5's existing body**
+
+In the existing `### Step 5: Meeting Action Items` section, after the
+"**Must run interactively in the foreground session.**" paragraph, append:
+
+```markdown
+In `--unattended` mode this step does NOT run interactively -- see Unattended
+Mode > Per-step deltas > Step 5 for the inline auto-todo + dedup flow.
+```
+
+- [ ] **Step 4: Verify no AskUserQuestion leaks into the unattended path**
+
+Run:
+
+```bash
+cd /Users/ian.bartholomew/.dotfiles/.claude/worktrees/end-of-day-unattended
+awk '/^## Unattended Mode/{f=1} f' stow-packages/claude/.claude/skills/end-of-day/SKILL.md | grep -c AskUserQuestion
+```
+
+Expected: `0` (the Unattended Mode section must reference no AskUserQuestion).
+Also confirm the section names every interactive step (2,3,4,5,6,9) plus Step 0:
+
+```bash
+awk '/^## Unattended Mode/{f=1} f' stow-packages/claude/.claude/skills/end-of-day/SKILL.md | grep -oE 'Step [0-9]+' | sort -u
+```
+
+Expected: includes Step 0, Step 2, Step 3, Step 4, Step 5, Step 6, Step 7, Step 9, Step 10.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add stow-packages/claude/.claude/skills/end-of-day/SKILL.md
+git commit -m "feat(end-of-day): add --unattended mode for scheduled runs"
+```
+
+### Task B2: start-of-day dead-man's-switch
+
+**Files:**
+
+- Modify: `stow-packages/claude/.claude/skills/start-of-day/SKILL.md`
+
+- [ ] **Step 1: Add the heartbeat check step**
+
+In `start-of-day/SKILL.md`, after `### Step 2.5: Work-board sync (live)` and before `### Step 3: Invoke the render script`, insert:
+
+````markdown
+### Step 2.6: End-of-day heartbeat check
+
+Confirm the previous business day actually ran its end-of-day pipeline. A
+missed unattended EOD leaves no `wiki/_log.md` entry -- a silent non-event.
+Surface its absence in the morning.
+
+```bash
+PREV=$(date -v-1d +%Y-%m-%d)         # Mon-Thu; on Monday use Friday:
+[ "$(date +%u)" = "1" ] && PREV=$(date -v-3d +%Y-%m-%d)
+grep -q "^## \[$PREV\] end-of-day" ~/Documents/Work/wiki/_log.md \
+  && echo "EOD heartbeat: $PREV ok" \
+  || echo "EOD heartbeat: WARNING no end-of-day entry for $PREV"
+```
+
+If the check warns, add a one-line "Yesterday's end-of-day did not run -- check
+the Desktop scheduled task" note to the start-of-day terminal summary (Step 5).
+Do not block the morning routine on it.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add stow-packages/claude/.claude/skills/start-of-day/SKILL.md
+git commit -m "feat(start-of-day): warn when prior end-of-day run is missing"
+```
+
+- [ ] **Step 3: Open the .dotfiles PR**
+
+```bash
+cd /Users/ian.bartholomew/.dotfiles/.claude/worktrees/end-of-day-unattended
+git push -u origin worktree-end-of-day-unattended
+gh pr create --title "end-of-day: unattended mode for scheduled runs" --body "Adds --unattended mode (no in-skill prompts, draft/dry-run external writes, auto daily-note, end-of-run notification, concurrency lock, catch-up date handling) and a start-of-day dead-man's-switch that warns when the prior day's EOD produced no wiki/_log.md entry. Spec + adversarial review in docs/superpowers/."
+```
+
+---
+
+## Workstream C — Local setup + migration (machine config, not PRs)
+
+> Do these AFTER both PRs are merged and the skills are re-stowed/active.
+
+### Task C1: settings.json allow + deny
+
+**Files:**
+
+- Modify: `~/.claude/settings.json`
+
+- [ ] **Step 1: Add the scoped allow entries**
+
+Add to `permissions.allow` (if not already present):
+
+```
+"Bash(rm -rf /tmp/eod-cache-threads:*)",
+"Bash(rm -f /tmp/eod-fes-support-cache.json:*)"
+```
+
+Confirm `Bash(td:*)` and `Bash(python3:*)` are already present (they are).
+
+- [ ] **Step 2: Audit the deny-list**
+
+Confirm `permissions.deny` still blocks the destructive patterns (`rm -rf /`,
+`rm -rf /*`, `mkfs`, `dd if=… of=/dev/*`, `curl|bash`, force-push to main).
+These remain the hard floor under `bypassPermissions`. No removals.
+
+- [ ] **Step 3: Validate JSON**
+
+Run: `python3 -m json.tool ~/.claude/settings.json > /dev/null && echo OK`
+Expected: `OK`
+
+### Task C2: Point the scheduled task at unattended mode
+
+**Files:**
+
+- Modify: `~/.claude/scheduled-tasks/end-of-day/SKILL.md`
+
+- [ ] **Step 1: Update the task body**
+
+Change the body from `/end-of-day` to `/end-of-day --unattended`. Keep the
+frontmatter `name`/`description`.
+
+### Task C3: Desktop UI permission mode (USER MANUAL STEP)
+
+- [ ] **Step 1: Set the task to bypassPermissions**
+
+In the Claude Code Desktop app: Routines/Scheduled tasks -> `end-of-day` ->
+edit -> set Permission mode to `bypassPermissions`; confirm schedule weekdays
+16:30; confirm the prompt body is `/end-of-day --unattended`. Save.
+
+Caveat: Desktop may silently revert this to `acceptEdits` (known bug). The
+allowlist backstop (C1) and the run's permission self-check (B1) exist for that
+case. Re-verify the mode after the first run.
+
+### Task C4: Backup the LaunchAgents
+
+**Files:**
+
+- Create: `~/Library/LaunchAgents-backup-<date>/`
+
+- [ ] **Step 1: Snapshot all three plists before any change**
+
+```bash
+BK=~/Library/LaunchAgents-backup-$(date +%Y%m%d-%H%M%S)
+mkdir -p "$BK"
+cp ~/Library/LaunchAgents/com.ian.eod.plist \
+   ~/Library/LaunchAgents/com.ian.sod.plist \
+   ~/Library/LaunchAgents/com.ian.standup.plist "$BK"/
+ls -la "$BK"
+```
+
+Expected: three plists copied. (Honors the "backup before destructive moves" rule.)
+
+### Task C5: Supervised first run + gate
+
+- [ ] **Step 1: Supervised dry run**
+
+With the Desktop task configured, manually run `/end-of-day --unattended` while
+watching. Walk the success checklist (Task B1, Step 2). Fix anything that
+stalls or fails; repeat until clean.
+
+- [ ] **Step 2: Two clean scheduled runs**
+
+Let the Desktop task fire on its own schedule. Confirm each run via the
+notification + the `wiki/_log.md` entry + the checklist. Require **2 consecutive
+clean scheduled runs** before proceeding.
+
+### Task C6: Remove the LaunchAgents
+
+> GATE: only after Task C5 Step 2 (two clean scheduled runs).
+
+- [ ] **Step 1: Unload and delete all three**
+
+```bash
+for j in eod sod standup; do
+  launchctl bootout gui/$(id -u)/com.ian.$j 2>/dev/null \
+    || launchctl unload ~/Library/LaunchAgents/com.ian.$j.plist 2>/dev/null
+  rm -f ~/Library/LaunchAgents/com.ian.$j.plist
+done
+launchctl list | grep com.ian || echo "no com.ian jobs remain"
+```
+
+Expected: `no com.ian jobs remain`; backups from C4 still exist.
+
+- [ ] **Step 2: Note the sod/standup follow-up**
+
+sod and standup are now off their always-on runner but have NOT received
+`--unattended` treatment, so their Desktop scheduled runs may stall on their own
+in-skill prompts. Run them manually if a scheduled run stalls; track converting
+start-of-day and daily-standup to `--unattended` as a follow-up.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: `--unattended` (B1), three-layer auth (C1 allow/deny + C3
+  bypassPermissions + B1 flag), threat model / deny floor (C1 Step 2 + B1
+  observability self-check), Todoist dedup non-terminal + match rule (A1/A2),
+  one terminal-state authority + model skip-not-dismiss (A3 + B1 Step 5),
+  external draft/dry-run (B1 Step 2 delta), observability + dead-man's-switch
+  (B1 + B2), safe migration sequencing + rollback via backups (C4/C5/C6),
+  concurrency lock (B1), catch-up date (B1), success checklist + DoD (B1 +
+  this plan's ordering). The `.mcp.json` sizing and auto-log out-of-scope items
+  are documentation-only in the spec, no task needed.
+- No placeholders: all code shown in full; all commands exact.
+- Type consistency: `find_duplicate`/`DEDUP_THRESHOLD`/`fetch_open_titles`
+  names match between A1, A2, and their tests; `duplicate` outcome string
+  matches between A2 code, A2 tests, A3 docs, and B1 Step 5.

--- a/docs/superpowers/specs/2026-06-17-end-of-day-unattended-design.md
+++ b/docs/superpowers/specs/2026-06-17-end-of-day-unattended-design.md
@@ -234,13 +234,15 @@ Reordered so EOD is never left non-functional:
 5. **Prove it scheduled:** let the Desktop task fire on its own and confirm a
    clean run via the checklist + notification. Require **2 consecutive clean
    scheduled runs**.
-6. **Only then** `launchctl bootout` + delete `com.ian.eod.plist`.
+6. **Only then** `launchctl bootout` + delete `com.ian.eod.plist`, AND
+   `com.ian.sod.plist` + `com.ian.standup.plist` (decided: remove all three).
 
-**sod/standup:** KEEP their LaunchAgents. Removing them now leaves their
-Desktop equivalents stalling on their own un-converted in-skill prompts. They
-come off LaunchAgent only after they receive the same `--unattended` treatment
-(separate follow-up). *(This reverses the earlier "remove all three" decision —
-flagged for explicit user confirmation at spec review.)*
+**sod/standup (decided: remove all three now).** Their LaunchAgents are removed
+in this change alongside EOD's. Accepted risk, explicitly: start-of-day and
+daily-standup have NOT received `--unattended` treatment, so their Desktop
+scheduled equivalents may stall on their own in-skill prompts until converted.
+Tracked follow-up: give start-of-day and daily-standup the same `--unattended`
+conversion. Until then, run them manually if a scheduled run stalls.
 
 **Rollback:** if the Desktop task proves unreliable after step 6, restore the
 EOD plist from backup (`launchctl bootstrap`) to return to the always-on runner.
@@ -266,8 +268,8 @@ Local machine setup (not PRs):
 1. `~/.claude/settings.json` — allow backstop + deny-list audit (direct edit;
    not stowed).
 2. `~/.claude/scheduled-tasks/end-of-day/SKILL.md` — `/end-of-day --unattended`.
-3. Remove `com.ian.eod` LaunchAgent (backup + unload + delete) — **only after**
-   2 clean scheduled runs.
+3. Remove `com.ian.eod`, `com.ian.sod`, `com.ian.standup` LaunchAgents (backup +
+   unload + delete) — EOD's **only after** 2 clean scheduled runs.
 4. Desktop UI permission mode → `bypassPermissions` (user manual step).
 
 **Cross-cutting DoD + ordering:** dedup PR merged → skill PR merged → settings
@@ -288,7 +290,8 @@ not "done" until the last item.
 ## Out of scope (with honest notes)
 
 - start-of-day / daily-standup `--unattended` treatment (follow-up; their
-  LaunchAgents stay until then).
+  LaunchAgents are removed in this change, so until the follow-up lands their
+  scheduled runs may stall — run manually if so).
 - Connector → local `.mcp.json` migration (sized above; deferred follow-up).
 - Auto-writing project `log.md` entries unsupervised.
 

--- a/docs/superpowers/specs/2026-06-17-end-of-day-unattended-design.md
+++ b/docs/superpowers/specs/2026-06-17-end-of-day-unattended-design.md
@@ -1,0 +1,310 @@
+# End-of-Day Unattended — Design
+
+Date: 2026-06-17
+Status: Draft for review (revised after adversarial review round 1)
+
+## Goal
+
+Make `/end-of-day` (currently v0.3.0, a 14-step interactive pipeline) able to
+run unsupervised as a local Claude Code Desktop scheduled task, with zero
+permission prompts and zero in-skill approval gates, while leaving the manual
+interactive experience unchanged. Meeting action items are auto-created, but
+deduped against the live Todoist list first so a scheduled run never creates a
+todo that already exists, and never silently buries a real commitment.
+
+## Background — why the current setup stalls
+
+Forensics over 2026-06-03 → 2026-06-17 (12 EOD runs, but only **one** real
+scheduled run, on 06-09 — small-n for the actual target environment) show the
+unsupervised stalls are **harness permission prompts**, not in-skill content
+gates:
+
+1. `Bash(rm -rf /tmp/eod-cache-threads ... /tmp/eod-fes-support-cache.json)` —
+   the Step 1.5 cache reset. `rm` is in no allowlist. Denied in the 06-09
+   scheduled run, which blocked the Slack steps. Top offender.
+2. MCP calls under rotating server-UUID identities that do not match the
+   friendly-name allowlist entries. Jira search failed twice with "permission
+   stream closed".
+3. Step-0 pre-flight MCP probes.
+
+Separately, the in-skill `AskUserQuestion` gates (Steps 3, 4, 5, 6, 9 and the
+error-handling continue/retry/halt prompts) cannot be answered unattended.
+
+## Execution model (decided)
+
+EOD moves off the hand-rolled `com.ian.eod` LaunchAgent onto a **local Claude
+Code Desktop scheduled task** (`~/.claude/scheduled-tasks/end-of-day/`).
+
+Accepted tradeoff: Desktop tasks fire only while the Desktop app is open and the
+Mac is awake; missed runs get one catch-up within 7 days. Reliability downgrade
+from the always-on LaunchAgent, accepted deliberately.
+
+**Prerequisite (must verify, not assume):** the Desktop app is installed, set to
+launch-at-login, and the `end-of-day` task is registered on the right schedule
+(weekdays 16:30) and exposes a per-task permission mode in its editor. If any of
+these is not true, the migration does not start.
+
+## Authorization design (decided) — three layers + threat model
+
+Local Desktop tasks read `~/.claude/settings.json` allow/deny rules AND carry a
+per-task permission mode set in the Desktop UI. In the default `ask` mode an
+unpermitted tool stalls indefinitely.
+
+Because Slack/Zoom/Atlassian are claude.ai **connectors** (not local `.mcp.json`
+servers), their tool names resolve to rotating UUIDs that cannot be durably
+allowlisted — allow rules cannot wildcard the server segment.
+
+- **Layer 1 — `bypassPermissions` per-task (primary).** Set in the Desktop UI.
+  Auto-approves regardless of tool name or UUID rotation. User manual step.
+- **Layer 2 — `settings.json` allow + deny.** Allow the deterministic,
+  non-rotating Bash so they never stall even if Desktop silently reverts to
+  `acceptEdits` (a known bug):
+  - `Bash(rm -rf /tmp/eod-cache-threads:*)`
+  - `Bash(rm -f /tmp/eod-fes-support-cache.json:*)`
+  - confirm `Bash(td:*)`, `Bash(python3:*)` present.
+  Deny rules still apply under `bypassPermissions` — see threat model.
+- **Layer 3 — `--unattended` skill flag.** Removes in-skill AskUserQuestion
+  gates and makes externally-visible writes draft/dry-run only (below).
+
+### Threat model for `bypassPermissions` (new)
+
+`bypassPermissions` auto-approves *every* tool call on a job that ingests
+untrusted content (Slack messages, Zoom transcripts, Jira tickets). That content
+is a prompt-injection surface: a crafted message could induce a destructive or
+exfiltrating `Bash`/MCP call with no human to catch it. Mitigations, layered:
+
+1. **Deny-list as the real containment.** `settings.json` `deny` rules are
+   honored even under `bypassPermissions`. The existing deny-list already blocks
+   `rm -rf /`, `mkfs`, `dd`, force-push to main, curl|bash, etc. Audit it and
+   add any EOD-relevant destructive patterns. This is the hard floor.
+2. **External writes are draft/dry-run only unattended** (Layer 3) — limits the
+   blast radius of any injected instruction to local, reviewable artifacts.
+3. **Known reversion bug.** Layer 1 may silently revert to `acceptEdits`
+   mid-run. The supervised-first-run gate (below) and the post-run self-check
+   detect this rather than discovering it after a bad run.
+
+### Durable alternative, honestly sized (was dismissed too fast)
+
+Migrating Slack/Zoom/Atlassian from claude.ai connectors to local `.mcp.json`
+servers would make the allowlist the durable lever (pinned server names, no UUID
+rotation, no need for blanket bypass). Rough size: one community/official MCP
+server per service (Slack, Zoom, Atlassian) wired in `~/.claude.json` with
+tokens in env, plus rewriting the skill's hardcoded `mcp__claude_ai_*` tool
+names to the pinned names — call it a 1-2 day spike with token-management and
+re-test risk. Deferred, not free; revisit if `bypassPermissions` proves too
+unreliable in practice. Tracked as a follow-up, not silently dropped.
+
+## The `--unattended` flag (decided: flag-gated)
+
+`/end-of-day` accepts an optional `--unattended` argument. Manual `/end-of-day`
+is unchanged. The scheduled task body becomes `/end-of-day --unattended`. To
+limit interactive/unattended drift, the two modes share every step's body and
+differ ONLY at the documented decision points below.
+
+### Concurrency guard (new, runs before anything)
+
+First action in `--unattended`: acquire an exclusive lock
+(`flock`/`mkdir` sentinel on `/tmp/eod.lock`). If held, abort immediately with a
+logged "already running" — prevents a catch-up run and a manual run from
+double-writing the shared `/tmp` caches and `_action-item-state.json`. Release
+on exit (including failure).
+
+### Run-date resolution under catch-up (new)
+
+`date +%Y-%m-%d` at run start defines "today" (already specified). A delayed
+catch-up therefore labels and processes against the **actual run day**, not the
+missed day. All source steps are "since last run", so no data is lost; the
+daily-note section is written for the run day. State this explicitly so a
+Saturday catch-up is understood, not surprising.
+
+### Per-step behavior in `--unattended`
+
+- **Step 0 (pre-flight MCP):** unchanged. On failure it HALTS — correct even
+  unattended; records the failure to the report + `wiki/_log.md` + the failure
+  notification (Observability).
+- **Step 1 (meeting-ingest, bg subagent):** unchanged.
+- **Step 1.5 (thread cache, `rm` + Slack reads):** unchanged logic; `rm`
+  covered by Layers 1/2.
+- **Step 2 (fes-support → Confluence, bg subagent):** **draft/hold only.** Do
+  NOT publish live Confluence pages unsupervised. Either publish as DRAFT or
+  write the would-be content to a local hold file for next-interactive review.
+  (Verify the fes-support-learnings skill's draft capability during
+  implementation; if it cannot draft, defer the publish entirely and surface in
+  the report.)
+- **Steps 3, 4 (support / internal learnings → `raw/`):** non-interactive with
+  the SAME explicit auto-default convention Step 2 already documents
+  (classification → `knowledge`, resolution → `unresolved`, domain → keyword-map
+  else `general`, duplicate → `skip`, other → skip/no-action). These write to
+  local `raw/` (not external), compiled later — acceptable unsupervised. Record
+  every auto-default for the report.
+- **Step 4.5 (join):** unchanged.
+- **Step 5 (meeting action items):** see Todoist dedup below. Inline, no
+  AskUserQuestion.
+- **Step 6 (project-log gate):** audit only (detection). Do NOT auto-write
+  `log.md` entries; record gaps in the report and surface in the Step 9 daily
+  note Follow-ups for next interactive session.
+- **Step 7 (compile):** non-interactive. Verify the compile sub-skill actually
+  supports a non-interactive path during implementation; do not assume.
+- **Step 8 (verify-status):** read-only, unchanged.
+- **Step 8.5 (work-board dry-run):** read-only report, unchanged.
+- **Step 9 (daily-note synthesis):** auto-write the drafted section (local,
+  idempotent upsert, post-write-verified by the existing `grep -c` check). The
+  daily note is the one external-ish surface intentionally auto-written because
+  it is local, reversible, and the user reads it. On the post-write check
+  failing (`0` or `>1`), do NOT proceed silently — log a failure marker and
+  include it in the notification.
+- **Step 10 (report):** append run summary to `wiki/_log.md` AND emit the
+  end-of-run notification (Observability), including resolved date,
+  auto-defaults applied, deduped/deferred items, Step-6 gaps deferred, and any
+  step failures.
+
+**Error handling in `--unattended`:** no continue/retry/halt prompts. Mid-run
+sub-skill failures are logged, the pipeline continues best-effort, and the
+failure is recorded in the report AND the notification. Step 0 pre-flight is the
+one hard halt. Pipeline-interruption handling is interactive-only.
+
+## Observability (new) — no silent failures
+
+1. **End-of-run notification.** Every `--unattended` run ends by sending a
+   `PushNotification` (tool available) with a one-line status: `ok` /
+   `degraded (N step failures)` / `halted (pre-flight)` plus the resolved date.
+   Degraded and halted are loud.
+2. **Dead-man's-switch via start-of-day.** "Run never fired" produces no
+   `wiki/_log.md` entry — a non-event nothing notices. Cheapest mitigation that
+   needs no new daemon: `/start-of-day` checks whether the prior business day
+   has an `end-of-day` `wiki/_log.md` entry and flags its absence in the morning.
+   (Small follow-up edit to start-of-day; in scope as a one-line check.)
+3. **Post-run permission self-check.** At the end of the run, assert the run did
+   not encounter a stall/timeout (proxy for `bypassPermissions` having reverted)
+   and include the result in the notification.
+
+## Todoist dedup (decided: revised after review)
+
+The "equals-or-is-contained-by" rule is removed — substring containment caused
+silent data loss ("Email Bob" ⊂ "Email Bob about Q3"). Replaced with two
+coherent, non-destructive layers that share ONE terminal-state authority.
+
+**Single terminal-state authority: the script (`meeting_action_items.py`).**
+The model semantic pass may only *downgrade* a candidate `todo → skip`; it can
+never write a permanent `dismiss`. Both layers reduce to the same outcome for a
+live-todo match: **not created this run, not permanently suppressed,
+re-evaluated next run.** This removes the precedence conflict the review flagged.
+
+- **Script backstop (in `apply`, protects every caller):**
+  - Before creating, query `td task list --project Work --json` once per
+    `apply` (cached for the batch).
+  - **Match rule:** normalized-equality OR token-set overlap ratio ≥ threshold
+    (default 0.85), NOT substring containment. Normalization is specified
+    precisely with test vectors (lowercase; NFKC unicode fold; strip leading
+    checkbox/bullet markers; collapse internal whitespace; strip trailing
+    punctuation; drop a small stop-word set). Emoji and unicode cases covered by
+    vectors.
+  - On match: skip creation, return a `duplicate` result carrying the matched
+    task URL, and **do not record terminal state** (so if the matched live todo
+    is later completed and the action item still applies, it resurfaces).
+  - "Open todo" scope is explicit: `--project Work`, top-level + subtasks,
+    excludes completed/archived and other projects. Documented in the test.
+  - Batch edge cases covered by tests: two candidates matching the same existing
+    todo; two candidates matching each other; candidate matching nothing.
+- **Model semantic pass (Step 5, unattended only):** catches reworded dupes the
+  string rule misses. Marks such candidates `skip` (non-terminal). A confidence
+  floor applies; low-confidence matches are NOT skipped — they go through as
+  todos (creating a near-dupe is recoverable; dropping a real commitment is
+  not). Each skip is logged with the matched todo for the report.
+- **Surfacing:** dropped/deferred candidates appear in the failure-visible
+  report and notification, not only an append-only log nobody reads.
+
+Existing per-item state (`<meeting_dir>::<sha256(normalized)[:12]>` → todoed |
+dismissed) is unchanged and remains the meeting+item-keyed dedup for items the
+user explicitly actioned in interactive runs.
+
+## Scheduling migration (decided) — safe sequencing
+
+Reordered so EOD is never left non-functional:
+
+1. **Backup** `com.ian.eod.plist` (and sod/standup, untouched) to a timestamped
+   dir.
+2. **Verify Desktop prerequisites** (app installed, launch-at-login, task
+   registered, schedule correct, permission-mode setting present).
+3. **Configure:** set `~/.claude/scheduled-tasks/end-of-day/SKILL.md` body to
+   `/end-of-day --unattended`; user sets the task permission mode to
+   `bypassPermissions` in the Desktop UI.
+4. **Supervised first-run gate:** run `/end-of-day --unattended` manually
+   (watching) and walk the success checklist (below). Fix anything; repeat.
+5. **Prove it scheduled:** let the Desktop task fire on its own and confirm a
+   clean run via the checklist + notification. Require **2 consecutive clean
+   scheduled runs**.
+6. **Only then** `launchctl bootout` + delete `com.ian.eod.plist`.
+
+**sod/standup:** KEEP their LaunchAgents. Removing them now leaves their
+Desktop equivalents stalling on their own un-converted in-skill prompts. They
+come off LaunchAgent only after they receive the same `--unattended` treatment
+(separate follow-up). *(This reverses the earlier "remove all three" decision —
+flagged for explicit user confirmation at spec review.)*
+
+**Rollback:** if the Desktop task proves unreliable after step 6, restore the
+EOD plist from backup (`launchctl bootstrap`) to return to the always-on runner.
+Note: restoring the runner does not undo a bad run's local writes — but because
+external writes are draft/dry-run only unattended, reversal is limited to local
+artifacts (daily note section re-upserts cleanly; Todoist state is
+non-terminal).
+
+## Scope summary + Definition of Done
+
+Version-controlled (2 PRs):
+
+1. `.dotfiles`: `stow-packages/claude/.claude/skills/end-of-day/SKILL.md` —
+   `argument-hint`, `--unattended` mode, concurrency lock, draft/dry-run
+   external writes, observability hooks, per-step behavior.
+   - Plus a one-line `start-of-day` dead-man's-switch check (same repo).
+2. `lyt-assistant`: `meeting_action_items.py` dedup backstop + tests (match
+   rule, normalization vectors, batch edge cases, non-terminal state, `--dry-run`
+   stays green).
+
+Local machine setup (not PRs):
+
+1. `~/.claude/settings.json` — allow backstop + deny-list audit (direct edit;
+   not stowed).
+2. `~/.claude/scheduled-tasks/end-of-day/SKILL.md` — `/end-of-day --unattended`.
+3. Remove `com.ian.eod` LaunchAgent (backup + unload + delete) — **only after**
+   2 clean scheduled runs.
+4. Desktop UI permission mode → `bypassPermissions` (user manual step).
+
+**Cross-cutting DoD + ordering:** dedup PR merged → skill PR merged → settings
+allow/deny edited → scheduled-task body updated → permission mode set →
+supervised first run green → 2 clean scheduled runs → EOD plist removed. EOD is
+not "done" until the last item.
+
+**"Successful unsupervised run" checklist (the success criterion):**
+
+- Pre-flight passed (not halted).
+- Slack steps (2/3/4) reached and produced output (or honest nothing-to-do).
+- No auto-default on any critical-publish step (Confluence stayed draft/deferred).
+- Step 5 dedup ran; report lists created vs deduped-vs-deferred; no silent drop.
+- Daily note section written and post-write check returned exactly 1.
+- End-of-run notification received with status `ok`.
+- `wiki/_log.md` has the run entry for the resolved date.
+
+## Out of scope (with honest notes)
+
+- start-of-day / daily-standup `--unattended` treatment (follow-up; their
+  LaunchAgents stay until then).
+- Connector → local `.mcp.json` migration (sized above; deferred follow-up).
+- Auto-writing project `log.md` entries unsupervised.
+
+## Verification
+
+- `meeting_action_items.py`: `python3 test_meeting_action_items.py` green,
+  including new dedup tests (match rule, normalization vectors, batch edge
+  cases, non-terminal state) and the existing `--dry-run` path.
+- Skill: the unattended section documents zero AskUserQuestion calls and the
+  draft/dry-run external-write behavior; the supervised first run (migration
+  step 4) is the integration test. Honest limitation: a markdown prompt's
+  runtime behavior cannot be unit-tested without executing the model — the
+  supervised gate + minimized interactive/unattended divergence are the
+  controls.
+- settings.json: allow entries present; deny-list audited.
+- Observability: trigger a deliberate failure in the supervised run and confirm
+  the notification fires `degraded`/`halted`.
+- LaunchAgents: after removal, `launchctl list | grep com.ian.eod` returns
+  nothing; sod/standup still present; backups exist.

--- a/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: end-of-day
 description: This skill should be used when the user asks to "end of day", "EOD", "run end of day", "wrap up the day", or runs "/end-of-day". Captures the day's Zoom + Slack signal into the wiki (with FES support learnings published to Confluence), reviews meeting action items into Todoist, audits project log.md files for today's entries, runs a verify-status snapshot, and synthesizes today's daily-note EOD section. Friday adds a weekly retrospective.
-version: 0.3.0
-allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent, TaskStop]
+version: 0.4.0
+argument-hint: "[--unattended]"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Agent, TaskStop, PushNotification]
 ---
 
 # End-of-Day Skill
@@ -29,6 +30,113 @@ Invoke this skill when:
 - If the user only wants the internal channel into `raw/`: use `/lyt-assistant:internal-channel-learnings`
 - If the user only wants to review meeting action items into Todoist: use `/lyt-assistant:meeting-action-items`
 - If the user only wants to compile already-collected sources: use `/lyt-assistant:compile`
+
+## Unattended Mode
+
+When invoked as `/end-of-day --unattended` (the scheduled Desktop task uses
+this), the pipeline runs with no human present. Manual `/end-of-day` is
+unchanged. Both modes share every step body; they differ ONLY at the points
+listed here. If the `--unattended` token is absent, ignore this entire section.
+
+### Global rules (unattended)
+
+- **No interactive prompts of any kind. No continue/retry/halt prompts.** Every place
+  the interactive flow would ask, take the documented auto-default and continue.
+- **Best-effort.** A mid-run sub-skill failure is logged to the report and the
+  run continues. The single exception is Step 0 pre-flight, which still HALTS.
+- **External/published writes are draft/dry-run only** (see Step 2). The local
+  daily note (Step 9) is the one surface auto-written, because it is local,
+  reversible, and idempotently upserted.
+- **End every run with a notification** (Observability, below).
+
+### Concurrency lock (first action, unattended)
+
+Before Step 0, acquire an exclusive lock so a catch-up run and a manual run
+cannot double-write the shared `/tmp` caches and `_action-item-state.json`:
+
+```bash
+if ! mkdir /tmp/eod.lock 2>/dev/null; then
+  echo "end-of-day already running (/tmp/eod.lock present); aborting."; exit 0
+fi
+```
+
+Remove `/tmp/eod.lock` (`rmdir /tmp/eod.lock`) as the final action of the run,
+including on any failure path that ends the run early.
+
+### Run-date under catch-up
+
+A Desktop task missed because the Mac was asleep fires a single catch-up within
+7 days. The cached `date +%Y-%m-%d` therefore reflects the **actual run day**,
+not the missed day. All source steps are "since last run", so nothing is lost;
+the daily-note section and report are labeled with the run day. This is expected
+behavior, not an error.
+
+### Per-step deltas (unattended)
+
+- **Step 0 (pre-flight):** unchanged; still HALTS on failure. On halt, send the
+  failure notification and release the lock before exiting.
+- **Step 2 (FES support -> Confluence):** the background subagent must run
+  **draft/hold only** -- do NOT publish a live Confluence page. Instruct it: if
+  the fes-support-learnings skill supports draft pages, publish as DRAFT;
+  otherwise write the would-be page content to
+  `raw/support_learnings/_pending_confluence/<date>.md` and report it as
+  deferred. Live Confluence publish is for interactive runs.
+- **Steps 3, 4 (support / internal -> raw/):** run non-interactively using the
+  exact auto-default convention Step 2 already documents (classification ->
+  `knowledge`, resolution -> `unresolved`, domain -> keyword-map else
+  `general`, duplicate -> `skip`, any other -> the skip/no-action option).
+  Record every auto-default for the report. (These write to local `raw/`, which
+  is reviewable and compiled later, so auto-defaulting is acceptable.)
+- **Step 5 (meeting action items):** run inline, no interactive prompts:
+  1. `python3 <skill-dir>/meeting_action_items.py list` -> candidates with
+     suggested title/due/priority.
+  2. `td task list --project Work --all --json` -> existing open todos.
+  3. Semantic pass: for each candidate that MEANS THE SAME as an existing open
+     todo (reworded duplicate the string layer would miss), mark it `skip`
+     (NON-terminal -- never `dismiss`). Only skip on high confidence; when
+     unsure, let it through as a `todo` (a near-dupe is recoverable; a dropped
+     commitment is not). Log each skip with the matched todo title.
+  4. Build the decisions JSON: surviving candidates -> `todo` with the script's
+     suggested due/priority; semantic dupes -> `skip`.
+  5. `python3 <skill-dir>/meeting_action_items.py apply --input <file>`. The
+     script independently dedups each `todo` against the live Work project and
+     returns `duplicate` (non-terminal) for any it catches -- this is the
+     deterministic backstop beneath the semantic pass.
+  Report created vs `skip` (semantic dupe) vs `duplicate` (script backstop);
+  never silently drop. (`<skill-dir>` is the meeting-action-items skill dir
+  announced when that skill loads.)
+- **Step 6 (project-log gate):** run the audit (detection) ONLY. Do NOT
+  auto-write `log.md` entries. Record each gap in the report and add it to the
+  Step 9 daily-note Follow-ups for the next interactive session.
+- **Step 7 (compile):** run non-interactively. (If the compile sub-skill exposes
+  any prompt, take its default.)
+- **Step 9 (daily-note synthesis):** auto-approve and write the drafted section.
+  The upsert and `grep -c '<!-- eod:begin'` post-write check are unchanged. If
+  the check returns `0` or `>1`, do NOT proceed silently: record a failure
+  marker and include it in the notification.
+- **Step 10 (report):** after writing the `wiki/_log.md` entry, send the
+  end-of-run notification (below), then release the lock.
+
+### Observability (unattended)
+
+- **End-of-run notification.** Send a `PushNotification` with a one-line status:
+  `end-of-day <date>: ok` / `end-of-day <date>: degraded (<N> step failures)` /
+  `end-of-day <date>: halted (pre-flight)`. Include the deduped/deferred counts
+  and any step failures in the body.
+- **Permission self-check.** If any tool call in the run was blocked or timed
+  out waiting on a permission decision (the symptom of the Desktop
+  `bypassPermissions` mode having silently reverted), treat the run as
+  `degraded` and say so in the notification -- this is how a reverted permission
+  mode gets surfaced instead of discovered later.
+
+### Success checklist (what "ran cleanly" means)
+
+A clean unattended run satisfies all of: pre-flight passed; Slack steps 2/3/4
+reached and produced output or an honest nothing-to-do; Confluence stayed
+draft/deferred; Step 5 reported created vs skip vs duplicate with no silent
+drop; the daily-note section was written and the post-write check returned
+exactly 1; the notification status is `ok`; and `wiki/_log.md` has the run entry
+for the resolved date.
 
 ## Pipeline Overview
 
@@ -299,6 +407,9 @@ Args: (none)
 ```
 
 **Must run interactively in the foreground session.** Invoke via the `Skill` tool in the main conversation — do NOT dispatch via `Agent` (background or foreground) and do NOT instruct it to "run non-interactively" like Step 2. The skill drives a per-item prompt loop that requires the user at the keyboard: `[t]` make todo / `[d]` dismiss / `[s]` skip / `[q]` quit, plus a bulk-triage shortcut. A subagent has no way to surface those prompts to the user, so dispatching it that way would either hang, auto-default every item, or silently dismiss work that should have become a todo.
+
+In `--unattended` mode this step does NOT run interactively -- see Unattended
+Mode > Per-step deltas > Step 5 for the inline auto-todo + dedup flow.
 
 Track for the run: number of items reviewed, number of new todos created, number dismissed, number skipped.
 

--- a/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
@@ -44,6 +44,10 @@ listed here. If the `--unattended` token is absent, ignore this entire section.
   the interactive flow would ask, take the documented auto-default and continue.
 - **Best-effort.** A mid-run sub-skill failure is logged to the report and the
   run continues. The single exception is Step 0 pre-flight, which still HALTS.
+- **Error Handling prompts auto-resolve.** Every continue/retry/halt
+  ([c]/[r]/[h]) and quit ([q]) prompt in the Error Handling section
+  resolves automatically to Continue: log the failure and proceed best-effort.
+  The sole exception is Step 0 pre-flight, which still halts.
 - **External/published writes are draft/dry-run only** (see Step 2). The local
   daily note (Step 9) is the one surface auto-written, because it is local,
   reversible, and idempotently upserted.
@@ -55,6 +59,11 @@ Before Step 0, acquire an exclusive lock so a catch-up run and a manual run
 cannot double-write the shared `/tmp` caches and `_action-item-state.json`:
 
 ```bash
+# clear an orphaned lock older than 6h (a prior run that died without cleanup),
+# then acquire atomically:
+if [ -d /tmp/eod.lock ] && find /tmp/eod.lock -maxdepth 0 -mmin +360 | grep -q .; then
+  rmdir /tmp/eod.lock 2>/dev/null
+fi
 if ! mkdir /tmp/eod.lock 2>/dev/null; then
   echo "end-of-day already running (/tmp/eod.lock present); aborting."; exit 0
 fi
@@ -679,6 +688,10 @@ Then append an end-of-day block to `wiki/_log.md`:
 If any steps failed or were skipped, list them in a `- Step failures:` line.
 
 ## Error Handling
+
+In `--unattended` mode, every prompt below auto-resolves to Continue (log and
+proceed best-effort); Step 0 pre-flight is the one exception that halts. See
+Unattended Mode > Global rules.
 
 ### A Sub-Skill Reports Its MCP Isn't Authed
 

--- a/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
@@ -266,6 +266,9 @@ If the check warns, add a one-line "Yesterday's end-of-day did not run -- check
 the Desktop scheduled task" note to the start-of-day terminal summary (Step 5).
 Do not block the morning routine on it.
 
+(This may emit a false warning the day after a US holiday, when the prior
+business day legitimately had no run. It is non-blocking, so that is acceptable.)
+
 ### Step 3: Invoke the render script
 
 The skill no longer composes markdown by hand. A deterministic Python script at `~/.claude/skills/start-of-day/render.py` reads the three JSON files written in Step 2 and emits the entire `## Start of Day` … `<!-- sod:end -->` block on stdout. The script owns whitespace and structure; the model captures stdout and uses it verbatim in Step 4.

--- a/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
@@ -248,6 +248,24 @@ documents; do not re-query JIRA). Include the sync summary (created / moved / co
 manual overrides / orphans) in the Step 5 terminal confirmation. A sync failure is
 non-fatal to start-of-day: report it and continue - the board is a view, not a gate.
 
+### Step 2.6: End-of-day heartbeat check
+
+Confirm the previous business day actually ran its end-of-day pipeline. A
+missed unattended EOD leaves no `wiki/_log.md` entry - a silent non-event.
+Surface its absence in the morning.
+
+```bash
+PREV=$(date -v-1d +%Y-%m-%d)         # Mon-Thu; on Monday use Friday:
+[ "$(date +%u)" = "1" ] && PREV=$(date -v-3d +%Y-%m-%d)
+grep -q "^## \[$PREV\] end-of-day" ~/Documents/Work/wiki/_log.md \
+  && echo "EOD heartbeat: $PREV ok" \
+  || echo "EOD heartbeat: WARNING no end-of-day entry for $PREV"
+```
+
+If the check warns, add a one-line "Yesterday's end-of-day did not run -- check
+the Desktop scheduled task" note to the start-of-day terminal summary (Step 5).
+Do not block the morning routine on it.
+
 ### Step 3: Invoke the render script
 
 The skill no longer composes markdown by hand. A deterministic Python script at `~/.claude/skills/start-of-day/render.py` reads the three JSON files written in Step 2 and emits the entire `## Start of Day` … `<!-- sod:end -->` block on stdout. The script owns whitespace and structure; the model captures stdout and uses it verbatim in Step 4.


### PR DESCRIPTION
Adds an --unattended mode to /end-of-day so it can run as a local Desktop scheduled task with no interactive prompts, and a start-of-day dead-man's-switch.

What:
- end-of-day SKILL.md: new Unattended Mode section. No interactive prompts; Error Handling continue/retry/halt prompts auto-resolve to Continue (Step 0 pre-flight still halts). Confluence writes draft/dry-run only; local daily note is the one auto-write. Concurrency lock with a 6h stale-lock guard. Catch-up date handling. End-of-run PushNotification. Frontmatter: argument-hint + PushNotification tool.
- start-of-day SKILL.md: Step 2.6 heartbeat warns when the prior business day has no end-of-day wiki/_log.md entry (catches a scheduled run that never fired).
- docs/superpowers: spec + plan + adversarial review.

Why: the scheduled EOD stalled on harness permission prompts and in-skill gates. Durable auth is a per-task bypassPermissions in the Desktop UI plus a settings allowlist backstop (local config, applied separately).

Companion PR (Todoist dedup backstop): ian-bartholomew/lyt-assistant#34.