### PR TITLE
end-of-day: hyphen not em dash in daily-note heading

### DIFF
--- a/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
@@ -528,7 +528,7 @@ Never construct the path manually. Do NOT write to `raw/daily/<date>.md`: that d
 **Default section template (append to existing daily note):**
 
 ```markdown
-## End of Day — <YYYY-MM-DD>
+## End of Day - <YYYY-MM-DD>
 
 <!-- eod:begin generated=<ISO-8601 UTC timestamp> -->
 


### PR DESCRIPTION
The daily-note EOD section heading was written with an em dash, which is disallowed in saved content. Switches the template to a hyphen. The upsert regex matches the '## End of Day' prefix, so existing em-dash headings self-heal on the next run. Found during the supervised --unattended integration test.