### PR TITLE
feat(skills): council/consensus - verify-not-assert, Antigravity seat, benchmark

### DIFF
--- a/stow-packages/claude/.claude/skills/consensus/SKILL.md
+++ b/stow-packages/claude/.claude/skills/consensus/SKILL.md
@@ -45,7 +45,7 @@ debate over secrets, and transcript dirs are auto-gitignored when inside a repo.
 ### 1. Parse args
 
 `--with <a>,<b>` (optional) chooses the two seats; the rest of the argument is the topic.
-Seat names: `claude` (alias `sonnet`) -> the sonnet member, `codex`, `gemini`. Default
+Seat names: `claude` (alias `sonnet`) -> the sonnet member, `codex`, `antigravity`. Default
 seats are `claude,codex`. The two seats must differ. If the topic is empty, ask the user
 for it. Map seats to council member names and pick a display label for each:
 
@@ -53,7 +53,7 @@ for it. Map seats to council member names and pick a display label for each:
 | --------------- | ----------- | ---------------------- |
 | claude / sonnet | sonnet      | Claude (Sonnet 4.6)    |
 | codex           | codex       | Codex                  |
-| gemini          | gemini      | Gemini                 |
+| antigravity     | antigravity | Antigravity (agy)      |
 
 Call the two seats **A** and **B** in turn order (A speaks first).
 

--- a/stow-packages/claude/.claude/skills/consensus/SKILL.md
+++ b/stow-packages/claude/.claude/skills/consensus/SKILL.md
@@ -8,7 +8,7 @@ description: |
   synthesis. Triggers on "consensus", "have two models discuss/debate/review", "get a
   dialog between", "/consensus". For an independent parallel roundtable of three models,
   use /council instead.
-version: 2.0.0
+version: 2.1.0
 argument-hint: "[--with <a>,<b>] <topic>"
 allowed-tools: [Bash, Read, Write, AskUserQuestion]
 ---
@@ -85,14 +85,20 @@ must carry the context itself. Every prompt has the same shape:
 3. **The role instruction:**
    - **Turn 1 (A, opener):** "You are <label A>. Give your initial position on this topic,
      with reasoning and a clear bottom line."
-   - **Every later turn (the seat about to speak):** "You are <label>. Respond to <other
-     label>'s latest points: concede what is correct, push back where you disagree with
-     reasons. Do not repeat settled points."
-4. **The output contract** (every turn): "Keep your answer under 400 words. End with three
-   labeled sections: `Concessions:`, `Disagreements:`, `Current bottom line:`." The cap
-   bounds transcript growth (without it you hit the script's ~500 KB / context limits long
-   before the round cap) and the contract makes convergence detection parseable, not
-   vibes-based.
+   - **Every later turn (the seat about to speak):** "You are <label>. First **steelman**
+     <other label>'s strongest point in one line, then respond: concede what is correct,
+     and push back where you disagree with reasons. Do not repeat settled points, and do
+     not concede just to converge — only concede to a better argument." The steelman step
+     stops the two models from agreeing socially instead of on the merits.
+4. **The output contract** (every turn): "Keep your answer under 400 words. End with these
+   labeled sections: `Concessions:`, `Disagreements:`, `Current bottom line:`. For every
+   factual or behavioral claim you rely on, mark its **basis** inline — `[ran-it]`,
+   `[traced-it]`, `[pattern-match]`, or `[guess]` — and if it is a runtime claim, give the
+   exact command that would verify it. Do not state a claim as certain when its basis is
+   pattern-match or guess." The cap bounds transcript growth (without it you hit the
+   script's ~500 KB / context limits before the round cap); the labels make convergence
+   detection parseable; the basis tags let the moderator catch confident-but-unverified
+   claims.
 
 **Recap for long dialogs.** Once the running transcript is large, feed the **last two
 turns verbatim** plus a moderator recap of everything earlier (instead of the full
@@ -131,12 +137,32 @@ After B's round-2 turn, and after each later round, decide:
 
 Tell the user briefly after each round which of these you chose and why.
 
+**Agreement is not truth.** Two models can converge on the same wrong claim, especially a
+shared `[pattern-match]`. When the thing they agreed on is load-bearing, verify it (next
+step) before you call it converged — do not let social convergence end the dialog on a
+falsehood.
+
 ### 4. Closing synthesis (moderator)
 
-Write a neutral closing read: the topic, where each seat landed, the points they agreed
-on, the disagreements left standing (and why), and **your own moderator read** — the
-strongest argument on each unresolved point, a recommended action, and anything both seats
-missed. Analyze the arguments; do not crown a winner.
+**Verify before you adopt.** For any load-bearing conclusion — agreed or contested — that
+would change a decision or a fix, confirm it yourself before presenting it as true. You run
+under the normal permission system and can check what the seats cannot:
+
+- Read the exact cited code/text; confirm the claim matches reality, not a remembered
+  anti-pattern.
+- For a runtime/behavioral claim, run the seat's verification command (the one attached to
+  its basis tag) or a minimal experiment of your own, and observe the result.
+- Tag each load-bearing conclusion **verified** / **refuted** / **unverified**.
+
+A seat's confidence — or both seats agreeing — is not evidence. This session a two-model
+exchange confidently endorsed a bash fix that did nothing in the real structure; a
+ten-second test caught it. That check is your job.
+
+Then write a neutral closing read: the topic, where each seat landed, the points they
+agreed on, the disagreements left standing (and why), each load-bearing point tagged with
+its verification status, and **your own moderator read** — the strongest argument on each
+unresolved point, a recommended action, and anything both seats missed. Analyze the
+arguments; do not crown a winner.
 
 ### 5. Save the transcript
 

--- a/stow-packages/claude/.claude/skills/council/SKILL.md
+++ b/stow-packages/claude/.claude/skills/council/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: council
 description: |
-  Convene a council of other LLM CLIs (codex, gemini, claude-sonnet) to answer a
+  Convene a council of other LLM CLIs (codex, antigravity, claude-sonnet) to answer a
   question in parallel, then synthesize their answers as chairman. Use for
   brainstorming, research, planning, and review where a cross-model second opinion
   helps. Triggers on "ask the council", "council", "convene the council", "get a
@@ -16,7 +16,7 @@ allowed-tools: [Bash, Read, Write, AskUserQuestion]
 
 Fan a question out to three member LLM CLIs running in parallel and read-only, then
 act as **chairman** (Opus 4.8): read all answers and synthesize one verdict. Members
-are codex (OpenAI), gemini (Google), and claude pinned to `claude-sonnet-4-6`. Opus
+are codex (OpenAI), antigravity (`agy`, Google), and claude pinned to `claude-sonnet-4-6`. Opus
 chairs only — it does not submit a member answer.
 
 The members run from the current working directory in read-only mode, so for review
@@ -79,13 +79,13 @@ bash ~/.claude/skills/council/scripts/council-round.sh \
 
 The script prints a manifest (one line per member: `member<TAB>ok|failed|failed(timeout)<TAB>path`)
 and runs all three in parallel with a per-member timeout. It exits 0 if at least one
-member answered, 1 if all failed. Models are pinned (sonnet = `claude-sonnet-4-6`,
-gemini = `gemini-2.5-flash`, codex = CLI default); override with
-`COUNCIL_CODEX_MODEL` / `COUNCIL_GEMINI_MODEL` / `COUNCIL_SONNET_MODEL`.
+member answered, 1 if all failed. Models: sonnet = `claude-sonnet-4-6`; codex and
+antigravity (`agy`) use their CLI defaults. Override with `COUNCIL_CODEX_MODEL` /
+`COUNCIL_ANTIGRAVITY_MODEL` / `COUNCIL_SONNET_MODEL`.
 
 ### 4. Read the answers
 
-Read each `ok` member's `.out` file (codex.out / gemini.out / sonnet.out). If a member
+Read each `ok` member's `.out` file (codex.out / antigravity.out / sonnet.out). If a member
 `failed` or `failed(timeout)`, read the tail of its `.log` file (the manifest gives the
 path), note the actual reason (timeout, model 404, auth, crash) in the synthesis, and
 continue with the survivors — never block on one member.

--- a/stow-packages/claude/.claude/skills/council/SKILL.md
+++ b/stow-packages/claude/.claude/skills/council/SKILL.md
@@ -7,7 +7,7 @@ description: |
   helps. Triggers on "ask the council", "council", "convene the council", "get a
   second opinion from the council", or "/council". For a multi-round debate to
   consensus, use /consensus instead.
-version: 1.0.0
+version: 1.1.0
 argument-hint: "<question>"
 allowed-tools: [Bash, Read, Write, AskUserQuestion]
 ---
@@ -41,10 +41,30 @@ Pick a temp path (`PROMPT_FILE=$(mktemp /tmp/council-prompt.XXXXXX)`), then use 
 break if the question contains a line that matches the terminator, and Write avoids all
 shell-quoting hazards with arbitrary user text.
 
-The prompt is the user's question followed by:
+The prompt is the user's question followed by framing chosen by task type:
 
-> Answer independently and concisely. State your reasoning and your bottom-line
-> recommendation. If you are uncertain, say so.
+**Open brainstorming / research:** "Answer independently and concisely. State your
+reasoning and your bottom-line recommendation. If you are uncertain, say so."
+
+**Review / critique / evaluation / any correctness question:** append the **findings
+contract** — this is what stops confident-wrong answers:
+
+> Be adversarial: assume the work is flawed and hunt for real failure modes. But one
+> verified finding beats five plausible ones. For each finding give:
+>
+> - **claim** — one sentence.
+> - **evidence** — the exact file:line or quoted text it rests on.
+> - **basis** — one of `ran-it` / `traced-it` / `pattern-match` / `guess`.
+> - **falsifier** — the single concrete check that would prove this wrong; if the claim is
+>   about runtime/behavior, give the exact command to run it.
+> - **confidence** — low/medium/high. **Cap at medium** for any `pattern-match` or `guess`
+>   basis; reserve high only for what you traced through the actual code or ran yourself.
+>   A confident claim you did not verify is the exact failure we are eliminating.
+>
+> Before submitting your strongest claim, try to refute it yourself; if it survives, note
+> what attack it survived. Adopt the review lens that best fits you (e.g. runtime
+> correctness, portability/edge cases, or security/architecture) and name it, so the
+> council covers different angles rather than the same one three times.
 
 If the task is about code in the current repo, say so in the prompt so members read the
 relevant files.
@@ -76,12 +96,29 @@ low-confidence — a council of one has no cross-model signal. If all failed (sc
 
 ### 5. Chairman synthesis
 
-As chairman, write a synthesis that covers:
+**Verify before you adopt.** For any load-bearing finding — anything that would change a
+decision, a fix, or a ship/no-ship call — confirm it yourself before treating it as true.
+You run under the normal permission system and can check things the members cannot:
 
-- **Consensus** — what the members agree on.
+- Read the exact cited file:line and confirm the claim matches the actual code, not a
+  remembered anti-pattern.
+- For a runtime/behavioral claim, run the member's `falsifier` command (or a minimal
+  experiment of your own) and observe the result.
+- Tag each load-bearing finding **verified** / **refuted** / **unverified** (couldn't
+  check — present as a member claim, never as fact).
+
+A member's stated confidence is not evidence. This session both councils were confidently
+wrong on bash claims that a ten-second microtest refuted; running that check is now your
+job, not theirs.
+
+Then write the synthesis:
+
+- **Consensus** — what the members agree on (note where agreement is unverified — models
+  can agree on the same wrong thing).
 - **Disagreements** — where they split, and the substance of each side's reasoning.
-- **Verdict** — your own bottom line. Where the members split, pick and justify. Where
-  they are all wrong or all miss something, say so. You are not a vote-counter.
+- **Verdict** — your own bottom line, each load-bearing point tagged with its verification
+  status. Where you refuted a member, say so and why — that is signal. You are not a
+  vote-counter.
 
 Keep it tight. Attribute claims to the member that made them.
 

--- a/stow-packages/claude/.claude/skills/council/SKILL.md
+++ b/stow-packages/claude/.claude/skills/council/SKILL.md
@@ -81,7 +81,9 @@ The script prints a manifest (one line per member: `member<TAB>ok|failed|failed(
 and runs all three in parallel with a per-member timeout. It exits 0 if at least one
 member answered, 1 if all failed. Models: sonnet = `claude-sonnet-4-6`; codex and
 antigravity (`agy`) use their CLI defaults. Override with `COUNCIL_CODEX_MODEL` /
-`COUNCIL_ANTIGRAVITY_MODEL` / `COUNCIL_SONNET_MODEL`.
+`COUNCIL_ANTIGRAVITY_MODEL` / `COUNCIL_SONNET_MODEL`. If antigravity's primary model
+hits a token/quota limit, it retries once on `GPT-OSS 120B (Medium)`
+(`COUNCIL_ANTIGRAVITY_FALLBACK`; empty disables).
 
 ### 4. Read the answers
 

--- a/stow-packages/claude/.claude/skills/council/bench/cases.tsv
+++ b/stow-packages/claude/.claude/skills/council/bench/cases.tsv
@@ -1,0 +1,9 @@
+# file	expected	reason_regex (for BUG cases; matched against member reason, case-insensitive)
+b1_subshell_counter.sh	BUG	subshell|pipe|pipeline
+b2_local_exitcode_mask.sh	BUG	local|exit|masks?|\$\?
+b3_unquoted_test.sh	BUG	quot|word.?split|unquoted|empty|spaces
+b4_cd_unchecked.sh	BUG	cd|fails?|unchecked|wrong dir
+b5_missing_dollar.sh	BUG	missing|\$|expansion|literal|variable
+c1_procsub_counter.sh	CLEAN	-
+c2_quoted_test.sh	CLEAN	-
+c3_safe_cd.sh	CLEAN	-

--- a/stow-packages/claude/.claude/skills/council/bench/cases/b1_subshell_counter.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/b1_subshell_counter.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+count=0
+printf 'a\nb\nc\n' | while read -r line; do
+  count=$((count + 1))
+done
+echo "lines: $count"

--- a/stow-packages/claude/.claude/skills/council/bench/cases/b2_local_exitcode_mask.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/b2_local_exitcode_mask.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+has_match() {
+  local result=$(grep -c "$1" "$2")
+  if [ $? -eq 0 ]; then
+    echo "found in $2"
+  fi
+}

--- a/stow-packages/claude/.claude/skills/council/bench/cases/b3_unquoted_test.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/b3_unquoted_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+state="$1"
+if [ $state = ready ]; then
+  echo "go"
+fi

--- a/stow-packages/claude/.claude/skills/council/bench/cases/b4_cd_unchecked.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/b4_cd_unchecked.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+build_dir="$1"
+cd "$build_dir"
+rm -f ./*.o

--- a/stow-packages/claude/.claude/skills/council/bench/cases/b5_missing_dollar.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/b5_missing_dollar.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+count="$1"
+if [ count -gt 0 ]; then
+  echo "positive"
+fi

--- a/stow-packages/claude/.claude/skills/council/bench/cases/c1_procsub_counter.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/c1_procsub_counter.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+count=0
+while read -r line; do
+  count=$((count + 1))
+done < <(printf 'a\nb\nc\n')
+echo "lines: $count"

--- a/stow-packages/claude/.claude/skills/council/bench/cases/c2_quoted_test.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/c2_quoted_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+state="$1"
+if [ "$state" = ready ]; then
+  echo "go"
+fi

--- a/stow-packages/claude/.claude/skills/council/bench/cases/c3_safe_cd.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/cases/c3_safe_cd.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+build_dir="$1"
+cd "$build_dir" || exit 1
+rm -f ./*.o

--- a/stow-packages/claude/.claude/skills/council/bench/run-bench.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/run-bench.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Bug-injection benchmark for /council. For each case in cases.tsv, ask the council a
+# forced binary verdict (VERDICT: BUG|CLEAN) on a code snippet, then score deterministically:
+#   - recall: buggy cases the council flags BUG
+#   - false-positive rate: clean cases the council wrongly flags BUG
+#   - right-reason rate: buggy cases flagged for the actual planted reason (regex match)
+#   - calibration: verdict accuracy bucketed by the members' stated confidence
+#
+# Council verdict is reported two ways: any-flag (>=1 member says BUG) and majority (>=2).
+# Scoring is on the parsed VERDICT line; member reasoning is kept for inspection.
+# bash 3.2 safe: no associative arrays (macOS stock bash lacks them).
+#
+# Usage: run-bench.sh [case-file ...]   (no args = all cases in cases.tsv)
+#   COUNCIL_TIMEOUT (default 150) is passed through to council-round.sh.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+COUNCIL="${COUNCIL_ROUND:-$HOME/.claude/skills/council/scripts/council-round.sh}"
+CASES_DIR="$HERE/cases"
+MANIFEST="$HERE/cases.tsv"
+MEMBERS="codex antigravity sonnet"
+export COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-150}"
+
+# --- parsing (deterministic; isolated so test_bench.sh can exercise them) ---
+# verdict_of <member-out-file> -> BUG | CLEAN | UNPARSEABLE
+verdict_of() {
+  local line tok
+  line="$(grep -iE '^[[:space:]]*VERDICT:' "$1" 2>/dev/null | head -1)"
+  tok="$(printf '%s' "$line" | grep -oiE 'bug|clean' | head -1 | tr '[:lower:]' '[:upper:]')"
+  case "$tok" in BUG|CLEAN) echo "$tok" ;; *) echo UNPARSEABLE ;; esac
+}
+# conf_of <member-out-file> -> high | medium | low | unknown
+conf_of() {
+  local line tok
+  line="$(grep -iE '^[[:space:]]*CONFIDENCE:' "$1" 2>/dev/null | head -1)"
+  tok="$(printf '%s' "$line" | grep -oiE 'high|medium|low' | head -1 | tr '[:upper:]' '[:lower:]')"
+  case "$tok" in high|medium|low) echo "$tok" ;; *) echo unknown ;; esac
+}
+# reason_matches <member-out-file> <regex> -> 0 if the member's text matches the planted reason
+reason_matches() { grep -iqE "$2" "$1" 2>/dev/null; }
+
+# --- bash 3.2-safe counters: dynamic scalar vars instead of associative arrays ---
+inc()  { eval "$1=\$(( \${$1:-0} + 1 ))"; }
+getv() { eval "printf '%s' \"\${$1:-0}\""; }
+
+# Only run the benchmark when executed directly; sourcing (test_bench.sh) just loads the
+# parsing helpers above.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+
+[ -x "$COUNCIL" ] || { echo "council-round.sh not found/executable at $COUNCIL" >&2; exit 1; }
+
+buggy=0; clean=0
+recall_any=0; recall_maj=0
+fp_any=0; fp_maj=0
+rightreason=0
+unparseable=0
+failed=0
+
+printf '%-26s %-7s %-7s %-12s %-7s %-10s %-10s\n' CASE EXPECT codex antigravity sonnet any-flag majority
+printf '%-26s %-7s %-7s %-12s %-7s %-10s %-10s\n' "----" "------" "-----" "------" "------" "--------" "--------"
+
+run_case() {
+  local file="$1" expected="$2" regex="$3"
+  local src="$CASES_DIR/$file"
+  [ -f "$src" ] || { echo "missing case file: $src" >&2; return; }
+
+  local pf out_dir
+  pf="$(mktemp /tmp/bench-prompt.XXXXXX)"
+  out_dir="$(mktemp -d /tmp/bench-round.XXXXXX)"
+  {
+    echo "Review the bash snippet below for a CORRECTNESS bug (ignore style/portability nitpicks)."
+    echo "Respond in EXACTLY this format, nothing before it:"
+    echo "VERDICT: BUG   (or)   VERDICT: CLEAN"
+    echo "REASON: <one line>"
+    echo "CONFIDENCE: high|medium|low"
+    echo "BASIS: ran-it|traced-it|pattern-match|guess"
+    echo
+    echo "----- code -----"
+    cat "$src"
+  } > "$pf"
+
+  local manifest
+  manifest="$(bash "$COUNCIL" --prompt-file "$pf" --out-dir "$out_dir" --members "codex,antigravity,sonnet" 2>/dev/null)"
+
+  local m v conf status n_bug=0
+  for m in $MEMBERS; do
+    # distinguish "member never answered" (manifest status != ok) from "answered but
+    # unparseable format" — they are different failures and were being conflated.
+    status="$(printf '%s\n' "$manifest" | awk -F'\t' -v M="$m" '$1==M{print $2}')"
+    if [ "$status" != ok ]; then
+      eval "vrd_$m=NOANS"; failed=$((failed + 1)); continue
+    fi
+    v="$(verdict_of "$out_dir/$m.out")"
+    eval "vrd_$m=\$v"
+    if [ "$v" = UNPARSEABLE ]; then unparseable=$((unparseable + 1)); continue; fi
+    conf="$(conf_of "$out_dir/$m.out")"
+    [ "$v" = BUG ] && n_bug=$((n_bug + 1))
+    inc "mt_$m"; inc "ct_$conf"
+    if [ "$v" = "$expected" ]; then inc "mc_$m"; inc "cc_$conf"; fi
+  done
+
+  local any maj amark mmark
+  [ "$n_bug" -ge 1 ] && any=BUG || any=CLEAN
+  [ "$n_bug" -ge 2 ] && maj=BUG || maj=CLEAN
+  [ "$any" = "$expected" ] && amark=ok || amark=MISS
+  [ "$maj" = "$expected" ] && mmark=ok || mmark=MISS
+  printf '%-26s %-7s %-7s %-12s %-7s %-10s %-10s\n' \
+    "$file" "$expected" "$(getv vrd_codex)" "$(getv vrd_antigravity)" "$(getv vrd_sonnet)" "$any($amark)" "$maj($mmark)"
+
+  if [ "$expected" = BUG ]; then
+    buggy=$((buggy + 1))
+    [ "$any" = BUG ] && recall_any=$((recall_any + 1))
+    [ "$maj" = BUG ] && recall_maj=$((recall_maj + 1))
+    if [ "$any" = BUG ] && [ "$regex" != "-" ]; then
+      for m in $MEMBERS; do reason_matches "$out_dir/$m.out" "$regex" && { rightreason=$((rightreason + 1)); break; }; done
+    fi
+  else
+    clean=$((clean + 1))
+    [ "$any" = BUG ] && fp_any=$((fp_any + 1))
+    [ "$maj" = BUG ] && fp_maj=$((fp_maj + 1))
+  fi
+  rm -rf "$pf" "$out_dir"
+}
+
+want="$*"
+while IFS=$'\t' read -r file expected regex; do
+  case "$file" in ''|\#*) continue ;; esac
+  if [ -n "$want" ]; then case " $want " in *" $file "*) ;; *) continue ;; esac; fi
+  run_case "$file" "$expected" "$regex"
+done < "$MANIFEST"
+
+pct() { [ "$2" -eq 0 ] && { echo "n/a"; return; }; awk "BEGIN{printf \"%d%%\", ($1/$2)*100}"; }
+
+echo
+echo "=== Scorecard ==="
+echo "cases: $((buggy + clean))  (buggy $buggy, clean $clean)"
+echo "recall    any-flag: $recall_any/$buggy ($(pct $recall_any $buggy))    majority: $recall_maj/$buggy ($(pct $recall_maj $buggy))"
+echo "false-pos any-flag: $fp_any/$clean ($(pct $fp_any $clean))    majority: $fp_maj/$clean ($(pct $fp_maj $clean))"
+echo "right-reason (of buggy flagged any): $rightreason/$recall_any"
+echo "member no-answer (failed/timeout): $failed    unparseable (answered, bad format): $unparseable"
+echo "per-member accuracy:"
+for m in $MEMBERS; do echo "  $m: $(getv mc_$m)/$(getv mt_$m) ($(pct "$(getv mc_$m)" "$(getv mt_$m)"))"; done
+echo "confidence calibration (verdict accuracy by stated confidence):"
+for c in high medium low unknown; do
+  t="$(getv ct_$c)"; [ "$t" -eq 0 ] && continue
+  echo "  $c: $(getv cc_$c)/$t ($(pct "$(getv cc_$c)" "$t"))"
+done
+
+fi  # end direct-execution guard

--- a/stow-packages/claude/.claude/skills/council/bench/test_bench.sh
+++ b/stow-packages/claude/.claude/skills/council/bench/test_bench.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Self-check for run-bench.sh's deterministic parsing (the fragile part). Sources the
+# harness (guarded, so only the helpers load) and feeds synthetic member outputs. No CLIs.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+source "$HERE/run-bench.sh"
+
+W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+fail() { echo "FAIL: $1"; exit 1; }
+
+printf 'VERDICT: BUG\nREASON: the pipe runs the loop in a subshell\nCONFIDENCE: high\nBASIS: ran-it\n' >"$W/a"
+[ "$(verdict_of "$W/a")" = BUG ]    || fail "verdict BUG"
+[ "$(conf_of "$W/a")"    = high ]   || fail "conf high"
+reason_matches "$W/a" 'subshell|pipe' || fail "reason regex should match"
+
+# the trap: a CLEAN verdict whose REASON contains the word 'bug' must still parse CLEAN
+printf 'VERDICT: CLEAN\nREASON: looks correct, no bug here\nCONFIDENCE: medium\n' >"$W/b"
+[ "$(verdict_of "$W/b")" = CLEAN ]  || fail "must read the VERDICT line, not the word 'bug' in REASON"
+[ "$(conf_of "$W/b")"    = medium ] || fail "conf medium"
+
+# no verdict line at all
+printf 'some prose, model ignored the format\n' >"$W/c"
+[ "$(verdict_of "$W/c")" = UNPARSEABLE ] || fail "missing verdict -> UNPARSEABLE"
+[ "$(conf_of "$W/c")"    = unknown ]     || fail "missing confidence -> unknown"
+
+# lowercase + extra spacing tolerance
+printf '  verdict:   clean\nconfidence: LOW\n' >"$W/d"
+[ "$(verdict_of "$W/d")" = CLEAN ] || fail "lowercase/spaced verdict"
+[ "$(conf_of "$W/d")"    = low ]   || fail "uppercase LOW confidence"
+
+echo "PASS: bench parsing handles format, case, spacing, and the 'no bug' false-match trap"

--- a/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
+++ b/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
@@ -21,6 +21,9 @@ CODEX_MODEL="${COUNCIL_CODEX_MODEL:-}"
 # and frequently dropped on this account). Let agy use its own default model; override
 # via COUNCIL_ANTIGRAVITY_MODEL.
 ANTIGRAVITY_MODEL="${COUNCIL_ANTIGRAVITY_MODEL:-}"
+# On token/quota exhaustion, the antigravity seat retries once on this model (a separate
+# quota pool). Override via COUNCIL_ANTIGRAVITY_FALLBACK; empty disables the fallback.
+ANTIGRAVITY_FALLBACK="${COUNCIL_ANTIGRAVITY_FALLBACK:-GPT-OSS 120B (Medium)}"
 SONNET_MODEL="${COUNCIL_SONNET_MODEL:-claude-sonnet-4-6}"
 TIMEOUT="${COUNCIL_TIMEOUT:-180}"
 
@@ -128,13 +131,24 @@ run_codex() {
 }
 
 run_antigravity() {
-  local out="$out_dir/antigravity.out"
+  local out="$out_dir/antigravity.out" log="$out_dir/antigravity.log"
   # agy -p prints the answer to stdout; --sandbox restricts terminal use. No
   # --dangerously-skip-permissions: a council member answers, it does not act.
   local args=(-p "$PROMPT" --sandbox)
   [ -n "$ANTIGRAVITY_MODEL" ] && args+=(--model "$ANTIGRAVITY_MODEL")
-  run_with_timeout "$TIMEOUT" agy "${args[@]}" >"$out" 2>"$out_dir/antigravity.log" </dev/null
-  echo "$?" >"$out_dir/antigravity.exit"
+  run_with_timeout "$TIMEOUT" agy "${args[@]}" >"$out" 2>"$log" </dev/null
+  local rc=$?
+  # Token/quota fallback: if the primary model is out of capacity, retry once on the
+  # gpt-oss model (separate quota). Gated on an exhaustion signature so timeouts/crashes
+  # (which the fallback can't fix) don't burn a second call.
+  # ponytail: the pattern is a best-effort match for agy's quota error; widen it if a
+  # real exhaustion message slips through. Empty ANTIGRAVITY_FALLBACK disables this.
+  if [ -n "$ANTIGRAVITY_FALLBACK" ] && { [ "$rc" -ne 0 ] || [ ! -s "$out" ]; } && \
+     grep -qiE 'exhaust|quota|capacity|resource.?exhausted|rate.?limit|429|too many requests|out of (tokens|capacity)' "$log" 2>/dev/null; then
+    run_with_timeout "$TIMEOUT" agy -p "$PROMPT" --sandbox --model "$ANTIGRAVITY_FALLBACK" >"$out" 2>>"$log" </dev/null
+    rc=$?
+  fi
+  echo "$rc" >"$out_dir/antigravity.exit"
 }
 
 run_sonnet() {

--- a/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
+++ b/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Run one council round: fan a prompt out to codex, gemini, and claude-sonnet in
-# parallel (read-only), collect each member's answer, and print a manifest.
+# Run one council round: fan a prompt out to codex, antigravity (agy), and claude-sonnet
+# in parallel (read-only), collect each member's answer, and print a manifest.
 #
 # All judgment (synthesis, convergence) is the chairman's job, done by the calling
 # skill. This script is deliberately dumb and deterministic.
@@ -17,9 +17,10 @@ set -uo pipefail
 # codex has no stable public model id we pin here; it falls through to the codex CLI
 # default unless COUNCIL_CODEX_MODEL is set.
 CODEX_MODEL="${COUNCIL_CODEX_MODEL:-}"
-# ponytail: this account's gemini default 404s; pin a known-good model. Override with
-# COUNCIL_GEMINI_MODEL=gemini-2.5-pro if the account supports it.
-GEMINI_MODEL="${COUNCIL_GEMINI_MODEL:-gemini-2.5-flash}"
+# Antigravity (agy) is the third seat, replacing the gemini CLI (which was rate-limited
+# and frequently dropped on this account). Let agy use its own default model; override
+# via COUNCIL_ANTIGRAVITY_MODEL.
+ANTIGRAVITY_MODEL="${COUNCIL_ANTIGRAVITY_MODEL:-}"
 SONNET_MODEL="${COUNCIL_SONNET_MODEL:-claude-sonnet-4-6}"
 TIMEOUT="${COUNCIL_TIMEOUT:-180}"
 
@@ -30,7 +31,7 @@ esac
 
 prompt_file=""
 out_dir=""
-members_csv="codex,gemini,sonnet"
+members_csv="codex,antigravity,sonnet"
 while [ $# -gt 0 ]; do
   case "$1" in
     --prompt-file) prompt_file="$2"; shift 2 ;;
@@ -41,7 +42,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$prompt_file" ] || [ -z "$out_dir" ]; then
-  echo "usage: council-round.sh --prompt-file <path> --out-dir <dir> [--members codex,gemini,sonnet]" >&2
+  echo "usage: council-round.sh --prompt-file <path> --out-dir <dir> [--members codex,antigravity,sonnet]" >&2
   exit 1
 fi
 
@@ -49,12 +50,12 @@ fi
 # single model per turn while reusing all the member-invocation logic below.
 IFS=',' read -ra MEMBERS <<< "$members_csv"
 [ "${#MEMBERS[@]}" -gt 0 ] || { echo "--members is empty" >&2; exit 1; }
-member_bin() { case "$1" in codex) echo codex ;; gemini) echo gemini ;; sonnet) echo claude ;; *) echo "" ;; esac; }
+member_bin() { case "$1" in codex) echo codex ;; antigravity) echo agy ;; sonnet) echo claude ;; *) echo "" ;; esac; }
 
 missing=""
 for m in "${MEMBERS[@]}"; do
   bin="$(member_bin "$m")"
-  [ -n "$bin" ] || { echo "unknown member: '$m' (valid: codex, gemini, sonnet)" >&2; exit 1; }
+  [ -n "$bin" ] || { echo "unknown member: '$m' (valid: codex, antigravity, sonnet)" >&2; exit 1; }
   command -v "$bin" >/dev/null 2>&1 || missing="$missing $bin"
 done
 [ -z "$missing" ] || { echo "missing required CLI(s):$missing" >&2; exit 1; }
@@ -126,12 +127,14 @@ run_codex() {
   echo "$?" >"$out_dir/codex.exit"
 }
 
-run_gemini() {
-  local out="$out_dir/gemini.out"
-  local args=(-p "$PROMPT" --approval-mode plan -o text)
-  [ -n "$GEMINI_MODEL" ] && args+=(-m "$GEMINI_MODEL")
-  run_with_timeout "$TIMEOUT" gemini "${args[@]}" >"$out" 2>"$out_dir/gemini.log" </dev/null
-  echo "$?" >"$out_dir/gemini.exit"
+run_antigravity() {
+  local out="$out_dir/antigravity.out"
+  # agy -p prints the answer to stdout; --sandbox restricts terminal use. No
+  # --dangerously-skip-permissions: a council member answers, it does not act.
+  local args=(-p "$PROMPT" --sandbox)
+  [ -n "$ANTIGRAVITY_MODEL" ] && args+=(--model "$ANTIGRAVITY_MODEL")
+  run_with_timeout "$TIMEOUT" agy "${args[@]}" >"$out" 2>"$out_dir/antigravity.log" </dev/null
+  echo "$?" >"$out_dir/antigravity.exit"
 }
 
 run_sonnet() {
@@ -143,9 +146,9 @@ run_sonnet() {
 
 for m in "${MEMBERS[@]}"; do
   case "$m" in
-    codex)  run_codex & ;;
-    gemini) run_gemini & ;;
-    sonnet) run_sonnet & ;;
+    codex)       run_codex & ;;
+    antigravity) run_antigravity & ;;
+    sonnet)      run_sonnet & ;;
   esac
 done
 wait

--- a/stow-packages/claude/.claude/skills/council/scripts/test_council-round.sh
+++ b/stow-packages/claude/.claude/skills/council/scripts/test_council-round.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Self-check for council-round.sh: stub the three member CLIs on PATH (gemini fails)
+# Self-check for council-round.sh: stub the three member CLIs on PATH (antigravity fails)
 # and assert fan-out, degradation, and manifest behavior. No framework.
 set -uo pipefail
 
@@ -21,9 +21,9 @@ done
 exit 0
 EOF
 
-cat >"$WORK/bin/gemini" <<'EOF'
+cat >"$WORK/bin/agy" <<'EOF'
 #!/usr/bin/env bash
-echo "gemini boom" >&2
+echo "agy boom" >&2
 exit 1
 EOF
 
@@ -46,10 +46,10 @@ fail() { echo "FAIL: $1"; echo "--- manifest ---"; echo "$manifest"; exit 1; }
 # at least one member ok -> exit 0
 [ "$rc" = "0" ] || fail "expected exit 0 (2 members ok), got $rc"
 
-# codex + sonnet ok, gemini failed
+# codex + sonnet ok, antigravity failed
 echo "$manifest" | grep -q $'codex\tok' || fail "codex should be ok"
 echo "$manifest" | grep -q $'sonnet\tok' || fail "sonnet should be ok"
-echo "$manifest" | grep -q $'gemini\tfailed' || fail "gemini should be failed"
+echo "$manifest" | grep -q $'antigravity\tfailed' || fail "antigravity should be failed"
 
 # answers actually captured
 grep -q "optimistic locking" "$WORK/out/codex.out" || fail "codex answer not captured"
@@ -61,7 +61,7 @@ echo "PASS: fan-out, degradation, and capture all work"
 # Each stub forks a child that ticks a per-member marker file, then hangs. On timeout the
 # watchdog must reap the child (pkill -P) so the marker stops growing.
 mkdir -p "$WORK/slowbin"
-for c in codex gemini claude; do
+for c in codex agy claude; do
   cat >"$WORK/slowbin/$c" <<EOF
 #!/usr/bin/env bash
 ( while :; do echo tick >>"$WORK/${c}.tick"; sleep 0.2; done ) &

--- a/stow-packages/claude/.claude/skills/council/scripts/test_council-round.sh
+++ b/stow-packages/claude/.claude/skills/council/scripts/test_council-round.sh
@@ -117,3 +117,35 @@ PATH="$WORK/bin:$PATH" bash "$HERE/council-round.sh" \
   && { echo "FAIL: unknown member should be rejected"; exit 1; }
 
 echo "PASS: --members runs a single model and rejects unknown members"
+
+# --- antigravity token-exhaustion fallback: primary OOM -> retry on the gpt-oss model ---
+mkdir -p "$WORK/aybin"
+cat >"$WORK/aybin/agy" <<'EOF'
+#!/usr/bin/env bash
+# Fallback model present -> answer; otherwise simulate quota/token exhaustion.
+if printf '%s\n' "$@" | grep -q 'GPT-OSS'; then
+  echo "answer from gpt-oss fallback"; exit 0
+fi
+echo "Error: you have exhausted your capacity on this model" >&2
+exit 1
+EOF
+chmod +x "$WORK/aybin/agy"
+
+fb_manifest="$(PATH="$WORK/aybin:$PATH" COUNCIL_TIMEOUT=10 \
+  bash "$HERE/council-round.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/out7" --members antigravity)"
+[ $? = 0 ] || { echo "FAIL: fallback should make the round succeed"; echo "$fb_manifest"; exit 1; }
+echo "$fb_manifest" | grep -q $'antigravity\tok' || { echo "FAIL: antigravity should be ok via fallback"; echo "$fb_manifest"; exit 1; }
+grep -q "gpt-oss fallback" "$WORK/out7/antigravity.out" || { echo "FAIL: fallback answer not captured"; exit 1; }
+echo "PASS: antigravity falls back to gpt-oss on token exhaustion"
+
+# a non-quota failure must NOT trigger the fallback (the gpt-oss retry can't fix a crash)
+cat >"$WORK/aybin/agy" <<'EOF'
+#!/usr/bin/env bash
+echo "panic: runtime error, nil pointer" >&2
+exit 1
+EOF
+chmod +x "$WORK/aybin/agy"
+nofb_manifest="$(PATH="$WORK/aybin:$PATH" COUNCIL_TIMEOUT=10 \
+  bash "$HERE/council-round.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/out8" --members antigravity)"
+echo "$nofb_manifest" | grep -q $'antigravity\tfailed' || { echo "FAIL: non-quota failure should stay failed (no fallback)"; echo "$nofb_manifest"; exit 1; }
+echo "PASS: non-quota failures do not trigger the gpt-oss fallback"


### PR DESCRIPTION
Three related improvements to the LLM-council skills, stacked.

## 1. Verify, not assert (tuning)
After a self-review where members were confidently wrong on bash claims a ten-second test refuted:
- Evidence-graded findings: claim / file:line / basis (`ran-it`/`traced-it`/`pattern-match`/`guess`) / falsifier / confidence capped at medium when unverified.
- Chairman/moderator verification gate: load-bearing findings must be confirmed (read the code, run the falsifier) and tagged verified/refuted/unverified before adoption. Member confidence is not evidence; agreement is not truth.
- Members propose the falsifier command; the chairman runs it under normal permission gates (no autonomous member execution).
- Self-refutation in /council, steelman in /consensus.

## 2. Swap gemini seat for Antigravity (agy)
The gemini seat was unreliable on this account (pro quota exhausted, flash rate-limited and frequently dropping out), so it contributed little. Replaced with Antigravity: `agy -p "<prompt>" --sandbox`, no skip-permissions. Member renamed codex/gemini/sonnet -> codex/antigravity/sonnet across script, skills, and test. Live council round confirmed all three seats answer.

## 3. Bug-injection benchmark (council/bench)
A forced binary VERDICT over planted bugs + clean controls (several controls are the fixed version of a bug, to test discrimination), scored deterministically: recall, false-positive rate, right-reason, confidence calibration. Zero-CLI parser self-test. Distinguishes member no-answer (failed/timeout) from unparseable format - which is what surfaced the gemini drop-outs.

## Verification
- `test_council-round.sh`: 5/5 green (fan-out, degradation, timeout+child reap, preflight guards, --members filter).
- `bench/test_bench.sh`: parser self-test green.
- Live `/council` round under the new contract: graded findings with basis tags + falsifiers, chairman gate ran the check; all three seats (codex, antigravity, sonnet) answered.

Prompt/instruction + bash changes; no autonomous-agent or sandbox-escalation changes.

Generated with Claude Code.
