### PR TITLE
feat(moa): add in-the-loop mixture-of-agents skill

### DIFF
--- a/stow-packages/claude/.claude/skills/moa/SKILL.md
+++ b/stow-packages/claude/.claude/skills/moa/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: moa
+description: |
+  Mixture of Agents woven into an agentic task. At each genuinely hard decision point,
+  consult the reference trio (codex, antigravity, claude-sonnet) as parallel proposers
+  across multiple Together-style refinement layers, then act as the aggregator: verify,
+  synthesize, and take the real action yourself. Use for hard tasks that benefit from
+  multiple model perspectives at each fork. Triggers on "moa", "mixture of agents",
+  "run this with MoA", or "/moa". For a one-shot cross-model answer use /council; for a
+  two-model debate use /consensus.
+version: 1.0.0
+argument-hint: "<task>"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
+---
+
+# MoA (in-the-loop mixture of agents)
+
+Run an agentic task where the *thinking* at each hard step is a Mixture of Agents. You
+(Opus 4.8) are the **aggregator / acting model**: at each decision point you fan the
+sub-question out to reference proposers, refine their answers over layers, then verify and
+act yourself. Reference seats are the council trio: codex (OpenAI), antigravity (`agy`,
+Google), and claude pinned to `claude-sonnet-4-6`.
+
+**What this is not:** Claude Code cannot intercept its own inference, so this is not a
+model-provider swap (as Hermes does) and it does not fire on every model call. It is a
+*consult-before-you-act protocol* that fires at the genuinely hard forks. Mechanical steps
+act directly with no consult. That selectivity is the cost governor: a consult is trio x
+layers CLI invocations, so firing it on every `ls` would be absurd.
+
+**Safety** (inherited from `/council`): members run read-only from the working directory
+with your full credentials, network, and any repo/MCP instructions, and their answers are
+written to disk. Do not consult over secrets you would not want read and saved. Keep
+transcript dirs out of commits (step 5 handles the `.gitignore`).
+
+## Workflow
+
+### 1. Scope the task
+
+Use the argument as the task. If empty, ask the user for it (AskUserQuestion or chat).
+State the task back in one line, then begin working it like a normal agentic task.
+
+### 2. Identify decision points as you go
+
+A **decision point** is a genuinely hard fork where multiple model perspectives change the
+outcome: choosing an approach/architecture, an ambiguous design or judgment call, a risky
+or hard-to-reverse edit, a subtle correctness question. **Not** decision points: reading a
+file, `ls`/`grep`, an obvious rename, a mechanical edit with one right answer. Act on those
+directly. Only decision points trigger a consult.
+
+### 3. At a decision point, run a MoA consult
+
+Write the sub-question plus the **minimal** relevant context (paths, constraints, the exact
+choice) to a prompt file with the **Write tool** (never a bash heredoc: arbitrary text and
+terminator collisions). If the sub-question is about repo code, say so and cite the files
+so proposers read them. Then:
+
+```bash
+OUT_DIR="$(mktemp -d /tmp/moa-consult.XXXXXX)"
+bash ~/.claude/skills/moa/scripts/moa-consult.sh \
+  --prompt-file "$PROMPT_FILE" --out-dir "$OUT_DIR" --layers 2
+```
+
+`moa-consult.sh` runs the proposer layers deterministically: layer 1 fans the question out
+to the trio in parallel; each later layer feeds the prior layer's proposals back to the
+proposers to refine (Together-style). It prints the path to `moa-final.md` (last line) and
+handles timeouts, quorum, and degradation. `--layers 2` is the default; use `--layers 1`
+for a cheaper single fan-out, `--layers 3` only for a genuinely hard fork. `--members`
+overrides the trio if you must.
+
+Read `moa-final.md`: the refined proposals from the last successful layer, labeled per
+member, with a per-layer status summary. If a whole layer failed it falls back to the last
+good layer; if every layer failed the script exits 1 and says so, so drop back to deciding
+unaided and note it.
+
+### 4. Aggregate, verify, then act
+
+You are the aggregator, not a vote-counter. **Verify before you adopt:** for any
+load-bearing claim (anything that changes the decision or the action), confirm it yourself,
+read the cited file:line, or run a quick check. Tag load-bearing points
+**verified / refuted / unverified**. A proposer's confidence is not evidence; proposers in
+this setup have been confidently wrong on claims a ten-second check refutes.
+
+Then state your synthesized decision briefly (what you took from whom, what you refuted and
+why), and **take the actual action** under the normal permission system: the edit, the
+command, the file. Continue the task to the next step or decision point.
+
+### 5. Log each consult
+
+Reuse the council transcript pattern. Replace `SUBQ` with the actual sub-question.
+
+```bash
+SUBQ='...the sub-question...'
+if ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  DEST="$ROOT/.claude/moa"
+  IGN="$ROOT/.gitignore"
+  grep -qxF '.claude/moa/' "$IGN" 2>/dev/null || printf '.claude/moa/\n' >>"$IGN"
+else
+  DEST="$HOME/.claude/moa-logs"
+fi
+mkdir -p "$DEST"
+SLUG="$(printf '%s' "$SUBQ" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | cut -c1-50 | sed 's/-$//')"
+TRANSCRIPT="$DEST/$(date +%Y%m%d-%H%M%S)-$$-$SLUG.md"
+```
+
+Write to `$TRANSCRIPT` (Write tool): the sub-question, the contents of `moa-final.md`, and
+your aggregation + decision. **Only after** confirming it wrote (`[ -s "$TRANSCRIPT" ]`),
+clean up: `rm -rf "$OUT_DIR" "$PROMPT_FILE"`. If the write failed, leave `$OUT_DIR` in place
+(it holds the only copy of the proposals) and tell the user where it is.
+
+### 6. Soft consult budget
+
+Track a running consult count and state it (e.g. "MoA consult 2/5"). Multi-layer x trio x
+many steps is the real cost. If a task looks like it will exceed **~5 consults**, stop and
+surface that to the user (AskUserQuestion): raise the cap, drop to `--layers 1`, or finish
+the rest unaided. Never silently fan out dozens of times.

--- a/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# One Mixture-of-Agents consult: stack N proposer rounds (Together-style layers) by
+# re-invoking council-round.sh, feeding each layer's proposer outputs into the next
+# layer's prompt. Deterministic and dumb: this script runs the PROPOSER layers only.
+# The FINAL aggregation + the resulting action are Claude's job (the aggregator/acting
+# model) -- this script just hands back the refined proposals in moa-final.md.
+#
+# Usage: moa-consult.sh --prompt-file <path> --out-dir <dir> [--layers N] [--members csv]
+#   --layers   number of proposer rounds (default 2). 1 == a single council fan-out.
+#   --members  csv passed straight through to council-round.sh (default: the trio).
+#
+# Env: MOA_COUNCIL_ROUND overrides the path to council-round.sh (used by the test).
+# Exit: 0 if the final good layer had >=1 proposer answer, 1 if every layer failed.
+
+set -uo pipefail
+
+COUNCIL_ROUND="${MOA_COUNCIL_ROUND:-$HOME/.claude/skills/council/scripts/council-round.sh}"
+
+prompt_file=""
+out_dir=""
+layers=2
+members="codex,antigravity,sonnet"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt-file) prompt_file="$2"; shift 2 ;;
+    --out-dir)     out_dir="$2"; shift 2 ;;
+    --layers)      layers="$2"; shift 2 ;;
+    --members)     members="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$prompt_file" ] || [ -z "$out_dir" ]; then
+  echo "usage: moa-consult.sh --prompt-file <path> --out-dir <dir> [--layers N] [--members csv]" >&2
+  exit 1
+fi
+case "$layers" in
+  ''|*[!0-9]*) echo "--layers must be a positive integer (got '$layers')" >&2; exit 1 ;;
+esac
+[ "$layers" -gt 0 ] || { echo "--layers must be greater than 0 (got '$layers')" >&2; exit 1; }
+[ -f "$prompt_file" ] || { echo "prompt file not found: $prompt_file" >&2; exit 1; }
+[ -x "$COUNCIL_ROUND" ] || [ -f "$COUNCIL_ROUND" ] || {
+  echo "council-round.sh not found at: $COUNCIL_ROUND (set MOA_COUNCIL_ROUND)" >&2; exit 1; }
+mkdir -p "$out_dir" || { echo "cannot create out-dir: $out_dir" >&2; exit 1; }
+
+ORIG="$(cat "$prompt_file")"
+
+# Emit each ok proposer's answer from <layer_dir> (per its manifest) under a labeled
+# heading. Reads the manifest on stdin (council-round.sh format: member<TAB>status<TAB>path).
+proposals_from_manifest() {
+  local layer_dir="$1" manifest="$2"
+  while IFS=$'\t' read -r member status _; do
+    [ "$status" = "ok" ] || continue
+    printf '## Response from %s\n\n' "$member"
+    cat "$layer_dir/$member.out"
+    printf '\n\n'
+  done <"$manifest"
+}
+
+REFINE_INSTRUCTION='Below are candidate responses from other models to the same query. Use the strongest points, correct any errors you find, and produce an improved, self-contained response. Do not merely copy one of them.'
+
+last_good_dir=""
+last_good_manifest=""
+declare -a layer_summaries=()
+
+for i in $(seq 1 "$layers"); do
+  layer_dir="$out_dir/layer$i"
+  manifest="$out_dir/layer$i.manifest"
+  mkdir -p "$layer_dir"
+
+  if [ "$i" -eq 1 ]; then
+    round_prompt="$prompt_file"
+  else
+    # Refinement prompt = original question + the immediately-prior layer's proposals.
+    round_prompt="$out_dir/layer$i.prompt"
+    {
+      printf '%s\n\n' "$ORIG"
+      printf -- '---\n\n%s\n\n' "$REFINE_INSTRUCTION"
+      proposals_from_manifest "$last_good_dir" "$last_good_manifest"
+    } >"$round_prompt"
+  fi
+
+  # council-round.sh prints the manifest to stdout and exits 0 if >=1 member answered.
+  bash "$COUNCIL_ROUND" --prompt-file "$round_prompt" --out-dir "$layer_dir" \
+    --members "$members" >"$manifest" 2>"$out_dir/layer$i.log"
+  round_rc=$?
+
+  ok_count="$(grep -c $'\tok\t' "$manifest" 2>/dev/null || echo 0)"
+  layer_summaries+=("layer$i: rc=$round_rc, ok=$ok_count")
+
+  if [ "$round_rc" -eq 0 ] && [ "$ok_count" -gt 0 ]; then
+    last_good_dir="$layer_dir"
+    last_good_manifest="$manifest"
+  else
+    # Whole layer failed: can't refine further. Keep the last good layer as final.
+    echo "moa: layer $i produced no answers (rc=$round_rc); using layer output up to $((i-1))" >&2
+    break
+  fi
+done
+
+final="$out_dir/moa-final.md"
+if [ -z "$last_good_dir" ]; then
+  {
+    printf '# MoA consult: all layers failed\n\n'
+    printf 'No proposer produced an answer. Per-layer status:\n\n'
+    printf -- '- %s\n' "${layer_summaries[@]}"
+  } >"$final"
+  echo "$final" # still tell the caller where the (empty) result is
+  exit 1
+fi
+
+{
+  printf '# MoA final proposals\n\n'
+  # shellcheck disable=SC2016  # backticks are literal markdown, not command substitution
+  printf 'Refined proposer responses from the last successful layer (`%s`). ' "$(basename "$last_good_dir")"
+  printf 'You are the aggregator: verify load-bearing claims before adopting, then synthesize and act.\n\n'
+  printf -- '- %s\n' "${layer_summaries[@]}"
+  printf '\n---\n\n'
+  proposals_from_manifest "$last_good_dir" "$last_good_manifest"
+} >"$final"
+
+echo "$final"
+exit 0

--- a/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Self-check for moa-consult.sh. Stubs the three member CLIs on PATH and drives the REAL
+# council-round.sh through moa-consult.sh, so this exercises the actual composition. The
+# stubs emit a different answer when they see the refinement instruction, letting us prove
+# that layer N+1 received layer N's proposals. No framework.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+COUNCIL_ROUND="$HERE/../../council/scripts/council-round.sh"
+[ -f "$COUNCIL_ROUND" ] || { echo "SKIP: council-round.sh not found at $COUNCIL_ROUND"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export MOA_COUNCIL_ROUND="$COUNCIL_ROUND"
+export COUNCIL_TIMEOUT=10
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# --- stubs: codex + sonnet answer (marking refinement rounds), antigravity always fails ---
+mkdir -p "$WORK/bin"
+cat >"$WORK/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+out=""; all="$*"
+while [ $# -gt 0 ]; do case "$1" in -o) out="$2"; shift 2 ;; *) shift ;; esac; done
+if echo "$all" | grep -q 'candidate responses'; then msg="codex refined"; else msg="codex layer1"; fi
+[ -n "$out" ] && echo "$msg" >"$out"
+exit 0
+EOF
+cat >"$WORK/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+if echo "$*" | grep -q 'candidate responses'; then echo "sonnet refined"; else echo "sonnet layer1"; fi
+exit 0
+EOF
+cat >"$WORK/bin/agy" <<'EOF'
+#!/usr/bin/env bash
+echo "agy boom" >&2; exit 1
+EOF
+chmod +x "$WORK/bin/"*
+
+echo "should this helper be bash or python" >"$WORK/prompt.txt"
+
+# --- case 1: two layers, degradation, and layer-2-sees-layer-1 refinement ---
+final="$(PATH="$WORK/bin:$PATH" bash "$HERE/moa-consult.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o1" --layers 2 | tail -1)"
+rc=$?
+[ "$rc" = "0" ] || fail "layers=2 should exit 0 (codex+sonnet ok), got $rc"
+[ "$final" = "$WORK/o1/moa-final.md" ] || fail "expected moa-final.md path, got '$final'"
+
+grep -q "codex layer1" "$WORK/o1/layer1/codex.out"   || fail "layer1 codex answer missing"
+[ -d "$WORK/o1/layer2" ]                             || fail "layer2 dir should exist"
+grep -q "codex refined" "$WORK/o1/layer2/codex.out"  || fail "layer2 codex should be the refined answer"
+
+# the refinement prompt must carry the instruction AND layer-1's proposals
+grep -q "candidate responses" "$WORK/o1/layer2.prompt" || fail "layer2 prompt missing refine instruction"
+grep -q "codex layer1"        "$WORK/o1/layer2.prompt" || fail "layer2 prompt missing codex layer1 proposal"
+grep -q "sonnet layer1"       "$WORK/o1/layer2.prompt" || fail "layer2 prompt missing sonnet layer1 proposal"
+
+# moa-final holds the FINAL (refined) proposals under labeled headings; agy absent
+grep -q "codex refined"       "$WORK/o1/moa-final.md" || fail "moa-final missing refined codex"
+grep -q "sonnet refined"      "$WORK/o1/moa-final.md" || fail "moa-final missing refined sonnet"
+grep -q "Response from codex"  "$WORK/o1/moa-final.md" || fail "moa-final missing labeled heading"
+echo "PASS: layers stack, layer 2 sees layer 1's proposals, degrades past failed agy"
+
+# --- case 2: layers=1 degenerates to a single fan-out ---
+PATH="$WORK/bin:$PATH" bash "$HERE/moa-consult.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o2" --layers 1 >/dev/null \
+  || fail "layers=1 should exit 0"
+[ ! -d "$WORK/o2/layer2" ]         || fail "layers=1 should not create layer2"
+grep -q "codex layer1" "$WORK/o2/moa-final.md" || fail "layers=1 moa-final missing codex answer"
+echo "PASS: layers=1 is a single council fan-out"
+
+# --- case 3: a layer that fails after a good one falls back to the last good layer ---
+# codex here fails ONLY on the refinement round; sonnet always fails -> layer2 has no ok.
+mkdir -p "$WORK/bin3"
+cat >"$WORK/bin3/codex" <<'EOF'
+#!/usr/bin/env bash
+out=""; all="$*"
+while [ $# -gt 0 ]; do case "$1" in -o) out="$2"; shift 2 ;; *) shift ;; esac; done
+echo "$all" | grep -q 'candidate responses' && exit 1
+[ -n "$out" ] && echo "codex layer1 only" >"$out"; exit 0
+EOF
+cat >"$WORK/bin3/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+cp "$WORK/bin/agy" "$WORK/bin3/agy"
+chmod +x "$WORK/bin3/"*
+PATH="$WORK/bin3:$PATH" bash "$HERE/moa-consult.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o3" --layers 2 >/dev/null \
+  || fail "fallback to last good layer should exit 0"
+grep -q "codex layer1 only" "$WORK/o3/moa-final.md" || fail "moa-final should hold layer1 after layer2 failed"
+echo "PASS: a failed layer falls back to the last good layer"
+
+# --- case 4: all layers fail -> exit 1, final names the failure ---
+mkdir -p "$WORK/bin4"
+for c in codex agy claude; do printf '#!/usr/bin/env bash\nexit 1\n' >"$WORK/bin4/$c"; done
+chmod +x "$WORK/bin4/"*
+PATH="$WORK/bin4:$PATH" bash "$HERE/moa-consult.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o4" --layers 2 >/dev/null \
+  && fail "all-fail should exit non-zero"
+grep -q "all layers failed" "$WORK/o4/moa-final.md" || fail "moa-final should report total failure"
+echo "PASS: total failure exits 1 and is reported"
+
+# --- case 5: bad --layers rejected ---
+bash "$HERE/moa-consult.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o5" --layers 0 >/dev/null 2>&1 \
+  && fail "--layers 0 should be rejected"
+bash "$HERE/moa-consult.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o6" --layers abc >/dev/null 2>&1 \
+  && fail "--layers abc should be rejected"
+echo "PASS: invalid --layers rejected"
+
+echo "ALL PASS"


### PR DESCRIPTION
## What

New `/moa` skill: a mixture-of-agents capability modeled on Nous Research's `hermes-agent`, driven by Claude Code orchestrating the council trio (codex, antigravity `agy`, `claude-sonnet-4-6`) as reference proposers.

At each genuinely hard decision point in an agentic task, Claude fans the sub-question out to the trio in parallel across Together-style refinement layers, then acts as the aggregator: verify load-bearing claims, synthesize, take the real action.

## Why

Hermes swaps MoA in as a virtual model provider. Claude Code can't intercept its own inference, so this is a consult-before-you-act protocol that fires only at decision points (mechanical steps act directly) rather than a provider swap. Selectivity is the cost governor.

## Files

- `skills/moa/SKILL.md` - the in-the-loop protocol (decision-point detection, aggregate/verify/act, transcript logging, soft ~5-consult budget).
- `skills/moa/scripts/moa-consult.sh` - deterministic multi-layer proposer orchestrator; reuses `council-round.sh`. Claude does the final aggregation + action.
- `skills/moa/scripts/test_moa-consult.sh` - 5-case self-check.

Reuses `council/scripts/council-round.sh` by absolute path (cross-skill dependency, noted for extraction if a third consumer appears). `/council` and `/consensus` untouched.

## Verification

- `shellcheck` clean on both scripts.
- Unit tests pass: layering, layer N+1 sees layer N proposals, degradation past a failed member, `--layers 1` single fan-out, failed-layer fallback, total-failure exit 1, bad-args rejection.
- Real end-to-end: a 2-layer consult against the live trio returned exit 0 with all three members ok in both layers; refinement prompt correctly carried prior-layer proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)