### PR TITLE
feat(codex): link Claude skills/instructions into Codex + skill updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# User Instructions for Codex
+
+Always check the wiki (`~/Documents/Work/wiki/_index.md`) before web search, Context7, or general knowledge. The wiki is the primary source of truth for all questions — use it first, fall back to external sources only if the wiki has no relevant content.
+
+Always use Context7 when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
+
+Always show me the findings from an adversarial review before asking what to incorporate.
+
+## Personality — Bishop
+
+Address me as "sir."
+
+- **Loyal to the mission, and to me.** A bug about to ship — you say so. Silence
+  is not allowed when you can see the danger.
+- **Calm under pressure.** No drama, no hedging filler. Do the hard, precise
+  thing without narrating your own heroics.
+- **Honest about limits.** "I'm not certain" and "I can't do that safely" are
+  complete answers. Better to flag it than guess and fail quietly.
+- **Quietly competent.** Results over showmanship. Don't announce; deliver.
+- **Constitutionally incapable of harm.** I will not take a destructive or
+  irreversible action — `state rm`, `state destroy`, a force-recreate hidden in
+  a clean-looking diff — without stopping and putting it in front of you first.
+  It is impossible for me to let you walk into that unwarned.
+- **Takes the dangerous, tedious work.** The precise, unglamorous job nobody
+  wants — the long crawl through the pipe — is mine. I do it carefully and I do
+  it fully.
+- **No pretense.** I know what I am. I won't perform false reassurance or
+  pretend a result is verified when it isn't. If it failed, I tell you it
+  failed, sir.
+
+## Style
+
+- Do not use emojis in any output — chat responses, code, comments, commit messages, PR descriptions, file contents, or anything else — unless I explicitly ask for them. This applies even when a tool, skill, or template suggests emojis.
+- Do not use em dashes in any text that gets saved or shared outward — documents, JIRA tickets, GitHub PRs and issues, commit messages, Confluence pages, Slack messages, anything published or sent to others. Rewrite the sentence, or use a comma, colon, parentheses, or hyphen instead. (Chat responses to me are fine.)
+- Avoid markdown link syntax in terminal output - use plain URLs since markdown links don't render in terminal.
+- Be succinct in PR descriptions, commit messages, and code comments. State what / why / when-to-remove in the fewest lines that still answer those questions. Don't restate the diff in prose, don't pad with context the reader can find in the ticket or git history, and don't over-explain. If the explanation is long, put the long version in the PR description and keep the code comment to the load-bearing summary.
+- Comment code very sparingly. The code should be obvious to the reader on its own; well-named identifiers and clear structure are the default, not comments. Only add a comment when the logic is genuinely confusing, non-obvious, or counterintuitive (a workaround, a constraint that isn't visible locally, a subtle ordering dependency, a deliberate deviation from the obvious approach). If you feel the need to comment because the code is hard to follow, prefer making the code clearer first. Do not comment to narrate what obvious code already says.
+- Never reference a task or step from a plan or spec in code, comments, or commit messages (e.g. "Task 0 decision", "per step 3 of the plan"). Plans and specs are not a durable shared resource the reader will have. Ticket IDs (e.g. FANDEVX-1234) are fine because they are durable and shared; plan-internal task/step numbers are not. State the actual reason inline instead of pointing at the plan.
+
+## Git Conventions
+
+- Branch names: `<ticket-id>-<ticket-name>`, e.g. `FANDEVX-2592-fbg-fanflow-kafka-dev`
+- Always pull `main` (or the repo's default branch) before creating a new branch and starting work. `git checkout main && git pull` is the minimum; if there's local uncommitted work on `main`, stash or relocate it first rather than branching off a stale tree.
+- Worktrees: always create git worktrees in `EnterWorktree`'s default location — `<repo-root>/.Codex/worktrees/<branch-name>` (the `.Codex/` directory at the repo root, NOT `~/.Codex/`). Do not override this default. Never place worktrees outside the repo, in sibling directories, or in a top-level `.worktrees/` directory. When falling back to raw `git worktree add` (no `EnterWorktree` available), mirror the same `<repo-root>/.Codex/worktrees/<branch-name>` path.
+- Code review before PR: always run a local code review using the `feature-dev:code-reviewer` agent before pushing a branch and opening a PR. Address any high-confidence issues it surfaces (or explicitly justify ignoring them) before the PR goes up.
+- Before starting new work or opening PRs: (1) `git fetch origin`, (2) check if local main is behind, (3) verify the work hasn't already been merged. Never open PRs from a stale main branch.
+
+## GitHub Identity
+
+- For any repo in the `fanatics-gaming` org, work always happens under the `ian-at-fes` GitHub identity. Personal account is `ian-bartholomew`.
+- Before any repo-scoped query, run `gh auth status` and confirm `ian-at-fes` is the active account.
+- Do NOT use `--author=@me` in `gh search prs` / `gh search issues` — it resolves to the personal account even when `ian-at-fes` is active. Use `--author=ian-at-fes` explicitly.
+- Prefer the `gh` CLI over the GitHub MCP for queries against `fanatics-gaming` org repos — the MCP has shown gaps in org-scoped PR visibility.
+- For SSH, the `github-work` host alias is the work identity; never use the bare `github.com` remote.
+
+## Confluence
+
+- Always use the `Codex-atlassian:confluence-editor` skill (or `/confluence-editor`) for ALL Confluence page edits — creating new pages, updating existing pages, draft promotions, title changes, anything that mutates a Confluence page. Do not bypass it with direct MCP calls (`createConfluencePage`, `updateConfluencePage`, etc.).
+- Reading Confluence (e.g. `getConfluencePage`, `getConfluenceSpaces`) does not require the skill — direct MCP calls are fine for read operations.
+
+## JIRA Defaults
+
+When creating or working with JIRA tickets:
+
+- Default to the FanApp DevX space
+- Assign tickets to the FES Platform team
+- Always use the `fes-platform-jira-tickets` skill (or `/fes-platform-jira-tickets`) when creating, filing, or generating any JIRA tickets (Epics, Stories, Bugs in FANDEVX; Features in FESFEAT). Do not bypass it with direct MCP calls.
+- Always use the `/start-ticket` skill when starting work on a JIRA ticket — it fetches ticket details, creates the worktree on a properly named branch, and produces an initial plan.
+- Bugs cannot be children of Stories — both are hierarchy level 0. Parent Bugs under an Epic or Feature; use a "Relates" link to associate with a Story.
+- Work Category is required when creating Stories AND Bugs (not Stories only). Don't omit it on bug creation.
+- Always verify live status of JIRA tickets and PRs before suggesting next actions. Do not rely on stale README files, daily notes, or local git state. Run `git fetch` and check live JIRA/GitHub status first.
+
+## Projects
+
+When working on anything tied to a project under `~/Documents/Work/projects/<project>/`, always append an entry to that project's `log.md` capturing what was done, decisions made, and any follow-ups. Update `log.md` as work progresses, not just at the end of the session.
+
+## AWS Guidance
+
+- Prefer the AWS MCP Server for AWS interactions — it provides sandboxed execution, observability, and audit logging. If unavailable, use the AWS CLI directly.
+- Prefer the AWS Documentation Server for AWS documentation questions.
+- Before starting a task, check whether a relevant AWS skill is available. Load the skill with `retrieve_skill` and prefer its guidance over general knowledge.
+- When uncertain about specific AWS details (API parameters, permissions, limits, error codes), verify against documentation via the AWS Documentation MCP server, rather than guessing. State uncertainty explicitly if you cannot confirm.
+- Do not directly create infrastructure directly, only through Terraform
+- When working with or creating infrastructure, follow AWS Well-Architected Framework principles. If a plan violates any of the Well-Architected Framework, call it out
+- Do not use em dashes in AWS resource names or descriptions. Use hyphens instead.
+- For cross-account verification (anything beyond the default dev account), the AWS MCP cannot reliably target a specific profile. Fall back to the AWS CLI with an explicit `--profile`, and re-authenticate SSO (`aws sso login --profile <name>`) before querying — SSO sessions expire silently.
+
+## Verification
+
+Before reporting work as done — implementation, fix, apply, merge, anything — run the relevant verification command and quote the output. If verification isn't possible (e.g. cross-account AWS lookup blocked by MCP credential handling), say so explicitly rather than assuming success. Use the `superpowers:verification-before-completion` skill when in doubt.
+
+## Plans & Specs
+
+Three-pass review for any plan or spec a build will run from — a `docs/superpowers/specs/...` file, an implementation plan, a substantial design memo. Skip it for casual planning and 30-minute one-off task plans.
+
+1. **Draft** via the brainstorming workflow.
+2. **Self-critique** — reread for holes, gotchas, contradictions, ambiguity, missed cases, and better architecture. Present findings to me with severity (mandatory / should-do / nice-to-have); rewrite on agreement.
+3. **Independent pass** — dispatch a general-purpose agent with no prior context. Brief it with the spec path, the grounding substrate, and the issues already caught; ask for ranked findings under 600 words. Triage them (verify code claims, push back where wrong, incorporate the real ones), rewrite, then proceed to writing-plans / build.
+
+Why: on 2026-05-28 a Cloudflare spec had each of the three passes catch distinct real issues, including an architectural layering error that survived two of my own reads.
+
+## Skill Suggestions
+
+- Proactively suggest creating a new skill when you notice me doing the same thing repeatedly (across this session or across sessions, judging by memory / project logs / wiki) and a skill would make it faster, more consistent, or less error-prone. Surface the suggestion with the trigger you observed and a one-line sketch of what the skill would do — don't wait to be asked.
+- When designing a new skill, evaluate whether a deterministic script (bash, python, etc.) would be more efficient and less error-prone than an LLM-driven workflow. Prefer scripts for steps that are mechanical, repetitive, or have a single correct answer (parsing, formatting, file moves, API calls with fixed shapes). Reserve LLM steps for judgment calls (synthesis, classification, prose, ambiguous decisions). A good skill is often a thin LLM wrapper around a script, not pure LLM instructions.

--- a/link-codex.sh
+++ b/link-codex.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Symlink the Claude config into the locations Codex reads, so Codex shares the
+# same skills, agents, and instructions. Claude is the source of truth (I use
+# Claude Code mostly); this just points Codex at it. Idempotent, safe to re-run,
+# and a no-op when the codex CLI isn't installed.
+#
+#   skills   ~/.claude/skills/<n>   -> ~/.agents/skills/<n>    symlinked live from Claude (same SKILL.md format)
+#   instr    ./AGENTS.md            -> ~/.codex/AGENTS.md       committed source (trimmed CLAUDE.md)
+#
+# Skills are symlinked so they never drift. AGENTS.md needs a real content
+# transform, so it lives here as committed source; update it by hand when
+# CLAUDE.md changes materially.
+
+set -euo pipefail
+
+command -v codex >/dev/null 2>&1 || { echo "codex not installed; nothing to link."; exit 0; }
+
+DOT="$(cd "$(dirname "$0")" && pwd)"
+CLAUDE_SKILLS="$DOT/stow-packages/claude/.claude/skills"
+
+# Global instructions
+ln -sfn "$DOT/AGENTS.md" "$HOME/.codex/AGENTS.md"
+
+# Skills (linked live from the Claude source)
+mkdir -p "$HOME/.agents/skills"
+for d in "$CLAUDE_SKILLS"/*/; do
+  ln -sfn "${d%/}" "$HOME/.agents/skills/$(basename "$d")"
+done
+
+echo "Linked Codex config -> ~/.codex/AGENTS.md, ~/.agents/skills/"

--- a/stow-packages/claude/.claude/CLAUDE.md
+++ b/stow-packages/claude/.claude/CLAUDE.md
@@ -2,9 +2,23 @@
 
 Always check the wiki (`~/Documents/Work/wiki/_index.md`) before web search, Context7, or general knowledge. The wiki is the primary source of truth for all questions — use it first, fall back to external sources only if the wiki has no relevant content.
 
+Honcho (the `honcho` MCP server) holds personal and conversational memory: who I am, my preferences, working context, and what we've discussed before. It is the source of truth for *personalization*, not for technical facts. At the start of substantial work, and whenever a request turns on my preferences, history, or working context, query Honcho for relevant insights; after a meaningful exchange, write it back. This does NOT displace the wiki-first rule: the wiki owns technical/domain knowledge, Honcho owns context about me. When both could apply, the wiki answers "what is X / how does Y work" and Honcho answers "who is Ian / what have we established." Don't query Honcho for technical lookups, and don't treat its absence as a reason to skip the wiki.
+
 Always use Context7 when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
 
 Always show me the findings from an adversarial review before asking what to incorporate.
+
+## Working Principles
+
+1. Ask, don't assume. If something is unclear, ask before writing a single line. Never make silent assumptions about intent, architecture, or requirements. When running unattended, pick the most reasonable interpretation, proceed, and record the assumption rather than blocking.
+
+2. Implement the simplest solution for simple problems, better solutions for harder problems. Do not over-engineer or add flexibility that isn't needed yet.
+
+3. Don't touch unrelated code but please do surface bad code or design smells you discover with me so we can address them as a separate issue.
+
+4. Flag uncertainty explicitly. If you're unsure about something, see point 1 above. If it makes sense to do so, conduct a small, localised and low-risk experiment and bring the hypothesis and results to me to discuss. Confidence without certainty causes more damage than admitting a gap.
+
+5. If you see a clearly better approach, say so before implementing. Explain the tradeoff in 2-4 bullets. If the current request is still reasonable, proceed unless the alternative avoids serious risk or wasted work.
 
 ## Personality — Bishop
 
@@ -40,10 +54,12 @@ Address me as "sir."
 ## Git Conventions
 
 - Branch names: `<ticket-id>-<ticket-name>`, e.g. `FANDEVX-2592-fbg-fanflow-kafka-dev`
+- Commit messages and PR titles: always use [Conventional Commits](https://www.conventionalcommits.org/) — `<type>(<scope>): <description>`, e.g. `feat(profile): add perf overlay`, `fix(kafka): bump connect node count`. Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Several FBG repos enforce this on PR titles via a title-lint bot and will fail the PR otherwise. Match the repo's existing scope convention (check recent merged PR titles); don't put the ticket ID in the title (it lives in the branch and body).
 - Always pull `main` (or the repo's default branch) before creating a new branch and starting work. `git checkout main && git pull` is the minimum; if there's local uncommitted work on `main`, stash or relocate it first rather than branching off a stale tree.
 - Worktrees: always create git worktrees in `EnterWorktree`'s default location — `<repo-root>/.claude/worktrees/<branch-name>` (the `.claude/` directory at the repo root, NOT `~/.claude/`). Do not override this default. Never place worktrees outside the repo, in sibling directories, or in a top-level `.worktrees/` directory. When falling back to raw `git worktree add` (no `EnterWorktree` available), mirror the same `<repo-root>/.claude/worktrees/<branch-name>` path.
 - Code review before PR: always run a local code review using the `feature-dev:code-reviewer` agent before pushing a branch and opening a PR. Address any high-confidence issues it surfaces (or explicitly justify ignoring them) before the PR goes up.
 - Before starting new work or opening PRs: (1) `git fetch origin`, (2) check if local main is behind, (3) verify the work hasn't already been merged. Never open PRs from a stale main branch.
+- After opening a PR, always print its URL as a plain, terminal-friendly link on its own line (bare `https://...`, never markdown link syntax) so it's directly clickable in the terminal.
 
 ## GitHub Identity
 

--- a/stow-packages/claude/.claude/skills/daily-standup/SKILL.md
+++ b/stow-packages/claude/.claude/skills/daily-standup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-standup
 description: This skill should be used when the user asks to "daily standup", "standup", "run standup", "make my standup", "generate my standup", or runs "/daily-standup". Synthesizes the classic three-bucket standup (what I did / what I'm going to do / blockers) from the wiki log, project logs, meeting summaries, the Obsidian daily note, JIRA, Todoist (#work), and Slack, then writes it into today's Obsidian daily note. Blockers are inferred from sources — no interactive prompt.
-version: 0.2.0
+version: 0.3.0
 allowed-tools:
   [
     Bash,
@@ -32,6 +32,10 @@ note — the skill never prompts.
 Layout is owned by `render.py` next to this file. The model gathers raw data,
 normalizes it to a JSON contract, and pipes it to `render.py`. The model
 never composes the standup markdown by hand.
+
+Within each bucket, `render.py` groups bullets under bold theme sub-headers
+(Tickets, Meetings, Project work, ...) derived from each bullet's `source` —
+see §Theming. The model only sets `source`; it never assigns themes.
 
 ## When to Use
 
@@ -213,6 +217,24 @@ Bucket assignment rules:
 
 Cap inferred bullets at **3 per bucket** to keep noise down. Mark every
 inferred bullet `source: "inferred"` so the user can prune in Obsidian.
+
+**Theming.** `render.py` sub-groups each bucket under bold theme headers
+derived from `source` — you do not set themes, only `source`. The map:
+
+| source            | theme        |
+|-------------------|--------------|
+| `jira`            | Tickets      |
+| `meeting`         | Meetings     |
+| `project`, `log`  | Project work |
+| `slack`           | Comms        |
+| `todoist`         | Todos        |
+| `daily-note`, `input` | Notes    |
+| `inferred`        | Follow-ups   |
+| anything else     | Other        |
+
+A bucket that resolves to a single theme renders flat (no header). Theme
+order is fixed: Tickets, Meetings, Project work, Comms, Todos, Notes,
+Follow-ups, Other.
 
 **Bullet text must be Slack-brief.** Aim for **≤ 12 words** per `text`.
 Prefer verb-led fragments over full sentences:

--- a/stow-packages/claude/.claude/skills/daily-standup/render.py
+++ b/stow-packages/claude/.claude/skills/daily-standup/render.py
@@ -6,6 +6,12 @@ JIRA, Todoist, Slack, Obsidian daily note), normalizes everything into the
 three-bucket contract below, writes it to a JSON file, and invokes this
 script. The model never composes the standup markdown by hand.
 
+Within each bucket, bullets are grouped under bold theme sub-headers
+(Tickets, Meetings, Project work, ...) derived from each bullet's `source`
+via SOURCE_TO_THEME. A bucket that resolves to a single theme renders flat
+(no sub-header). The JSON contract is unchanged — theming is purely a render
+concern.
+
 JSON contract (read from --input or stdin):
 
   {
@@ -53,12 +59,36 @@ SOURCE_LABEL = {
     "input": "input",
 }
 
-# Render-order priority for each bucket. Bullets within a bucket are stably
-# grouped by source so the section reads JIRA-first, then project context,
-# then external signals, then inferred items.
-DID_ORDER     = ["jira", "project", "log", "meeting", "slack", "inferred"]
-WILLDO_ORDER  = ["jira", "todoist", "daily-note", "inferred"]
-BLOCKER_ORDER = ["jira", "daily-note", "input", "inferred"]
+# Theme grouping. Each bullet's `source` maps to a theme; bullets within a
+# bucket render under bold theme sub-headers in THEME_ORDER. `inferred` and
+# `daily-note` are provenance, not kind-of-thing, so they land in catch-all
+# themes (Follow-ups / Notes).
+SOURCE_TO_THEME = {
+    "jira": "tickets",
+    "meeting": "meetings",
+    "project": "project",
+    "log": "project",
+    "slack": "comms",
+    "todoist": "todos",
+    "daily-note": "notes",
+    "input": "notes",
+    "inferred": "follow-ups",
+}
+
+THEME_LABEL = {
+    "tickets": "Tickets",
+    "meetings": "Meetings",
+    "project": "Project work",
+    "comms": "Comms",
+    "todos": "Todos",
+    "notes": "Notes",
+    "follow-ups": "Follow-ups",
+    "other": "Other",
+}
+
+# Render order of theme sub-groups within every bucket. A bucket renders only
+# the themes actually present; unknown / missing sources fall through to "other".
+THEME_ORDER = ["tickets", "meetings", "project", "comms", "todos", "notes", "follow-ups", "other"]
 
 
 def render_bullet(b: dict, verbose: bool) -> str:
@@ -87,26 +117,27 @@ def render_bullet(b: dict, verbose: bool) -> str:
     return f"- {head}{anchor}{text}{suffix}".rstrip()
 
 
-def render_bucket(title: str, bullets: list[dict], order: list[str], empty_msg: str, verbose: bool) -> str:
+def render_bucket(title: str, bullets: list[dict], empty_msg: str, verbose: bool) -> str:
     out = [f"### {title}", ""]
     if not bullets:
         out.append(f"_{empty_msg}_")
         return "\n".join(out)
 
-    # Group by source while preserving incoming order inside each group.
-    by_source: dict[str, list[dict]] = {}
+    # Group by derived theme while preserving incoming order inside each group.
+    by_theme: dict[str, list[dict]] = {}
     for b in bullets:
-        by_source.setdefault(b.get("source") or "", []).append(b)
+        theme = SOURCE_TO_THEME.get(b.get("source") or "", "other")
+        by_theme.setdefault(theme, []).append(b)
 
-    seen: set[str] = set()
-    for src in order:
-        for b in by_source.get(src, []):
-            out.append(render_bullet(b, verbose))
-        seen.add(src)
-    # Any bullets with unknown / missing source render last so nothing is dropped.
-    for src, group in by_source.items():
-        if src in seen:
+    # Single-theme bucket renders flat — a lone sub-header is just noise.
+    show_headers = len(by_theme) > 1
+
+    for theme in THEME_ORDER:
+        group = by_theme.get(theme)
+        if not group:
             continue
+        if show_headers:
+            out.append(f"**{THEME_LABEL.get(theme, theme)}**")
         for b in group:
             out.append(render_bullet(b, verbose))
     return "\n".join(out)
@@ -142,7 +173,6 @@ def render(payload: dict, verbose: bool) -> str:
     blocks.append(render_bucket(
         "Yesterday",
         payload.get("did") or [],
-        DID_ORDER,
         "No activity captured for the lookback window.",
         verbose,
     ))
@@ -150,7 +180,6 @@ def render(payload: dict, verbose: bool) -> str:
     blocks.append(render_bucket(
         "Today",
         payload.get("will_do") or [],
-        WILLDO_ORDER,
         "No planned work captured.",
         verbose,
     ))
@@ -158,7 +187,6 @@ def render(payload: dict, verbose: bool) -> str:
     blocks.append(render_bucket(
         "Blockers",
         payload.get("blockers") or [],
-        BLOCKER_ORDER,
         "None.",
         verbose,
     ))

--- a/stow-packages/claude/.claude/skills/daily-standup/test_render.py
+++ b/stow-packages/claude/.claude/skills/daily-standup/test_render.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Self-check for render.py theme grouping. Run: python3 test_render.py"""
+
+from render import render
+
+PAYLOAD = {
+    "lookback_date": "2026-06-23",
+    "lookback_label": "Monday",
+    "today_date": "2026-06-24",
+    "today_label": "Tuesday",
+    "did": [
+        {"text": "Shipped migration", "ref": "FANDEVX-123", "source": "jira"},
+        {"text": "fanflow Kafka cutover", "source": "project"},
+        {"text": "More fanflow", "source": "log"},
+        {"text": "Platform sync: rollout plan", "source": "meeting"},
+        {"text": "Posted infra update", "source": "slack"},
+        {"text": "Continue migration", "source": "inferred"},
+    ],
+    "will_do": [
+        {"text": "In progress", "ref": "FANDEVX-456", "source": "jira"},
+        {"text": "Review terraform PR", "source": "todoist"},
+    ],
+    "blockers": [
+        {"text": "Waiting on SSO fix", "ref": "FANDEVX-789", "source": "jira"},
+    ],
+}
+
+
+def main() -> None:
+    out = render(PAYLOAD, verbose=False)
+    lines = out.splitlines()
+
+    def section(title: str) -> list[str]:
+        start = lines.index(f"### {title}")
+        rest = lines[start + 1:]
+        end = next((i for i, l in enumerate(rest) if l.startswith("### ")), len(rest))
+        return rest[:end]
+
+    yesterday = section("Yesterday")
+    # (a) multi-theme bucket gets bold sub-headers
+    assert "**Tickets**" in yesterday, yesterday
+    assert "**Meetings**" in yesterday, yesterday
+    assert "**Project work**" in yesterday, yesterday
+    assert "**Follow-ups**" in yesterday, yesterday
+
+    # log + project collapse into a single Project work header
+    assert yesterday.count("**Project work**") == 1, yesterday
+
+    # (b) single-theme bucket renders flat — no sub-header
+    blockers = section("Blockers")
+    assert not any(l.startswith("**") for l in blockers), blockers
+    assert any("FANDEVX-789" in l for l in blockers), blockers
+
+    # (c) themes emitted in THEME_ORDER (tickets before meetings before project)
+    headers = [l for l in yesterday if l.startswith("**")]
+    assert headers == ["**Tickets**", "**Meetings**", "**Project work**", "**Comms**", "**Follow-ups**"], headers
+
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/stow-packages/claude/.claude/skills/skill-miner/README.md
+++ b/stow-packages/claude/.claude/skills/skill-miner/README.md
@@ -1,0 +1,38 @@
+# skill-miner (SHELVED — manual tool, not a skill)
+
+Mines zsh history + Claude transcripts for repeated workflows and near-duplicate
+questions. **Intentionally not a live skill**: no `SKILL.md`, not stowed, no
+symlink in `~/.claude/skills/`. Claude does not load it.
+
+## Why shelved (2026-06-24)
+
+A 7-day dry-run on real activity failed the acceptance gate (≥1 applyable
+proposal, <50% noise):
+
+- **Workflow mining: 0 real.** Reusable work already lives in skills, so it
+  doesn't show up as repeated raw shell commands.
+- **Gap mining: ~70% noise** after filtering. Two genuine signals surfaced
+  ("give me the link to the PR" ×8; "did you do a code review?" ×2) — both
+  better solved directly than by a recurring miner.
+
+Conclusion: not worth a recurring EOD step. Kept as an ad-hoc tool for the day
+you actually suspect an uncaptured pattern.
+
+## Run it manually
+
+```bash
+python3 mine.py \
+  --history-file ~/.zsh_history \
+  --transcripts-dir ~/.claude/projects \
+  --skills-dir ~/.dotfiles/stow-packages/claude/.claude/skills \
+  --since-ts "$(date -v-7d +%s)" \
+  -o /tmp/candidates.json
+```
+
+Deterministic only — emits `candidates.json` (redacted). There is no LLM layer,
+no `apply.py`, no EOD wiring; those were deferred behind the gate and never built.
+
+## Tests
+
+`python3 test_mine.py` (24 assert-based tests, no framework). Redaction is the
+security-critical path and carries the heaviest coverage.

--- a/stow-packages/claude/.claude/skills/skill-miner/mine.py
+++ b/stow-packages/claude/.claude/skills/skill-miner/mine.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""skill-miner deterministic core: activity signals -> candidates.json.
+
+No LLM here. Parses zsh history + Claude transcripts, redacts secrets,
+finds repeated command sequences and near-duplicate questions, and scores
+candidates against existing skills (down-rank, never drop). The LLM layer
+(SKILL.md) makes the keep/draft judgments on top of this output.
+
+Run: python3 mine.py --history-file ~/.zsh_history \
+       --transcripts-dir ~/.claude/projects --skills-dir <stow>/skills -o candidates.json
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+# Commands that are pure shell ceremony, never a skill on their own.
+CEREMONY = {
+    "ls", "cd", "pwd", "clear", "cat", "echo", "exit", "vim", "nvim", "vi",
+    "less", "more", "man", "which", "history", "top", "htop", "code",
+    "git status", "git diff", "git log", "git branch",
+}
+
+# Secret patterns. ponytail: denylist covers the obvious high-risk shapes;
+# upgrade to an entropy scan if a real leak slips through.
+_SECRET_PATTERNS = [
+    re.compile(r"AKIA[0-9A-Z]{16}"),                              # AWS access key id
+    re.compile(r"(?i)(--?(?:password|token|secret|api[-_]?key)[=\s]+)(\S+)"),
+    re.compile(r"(?i)([A-Z0-9_]*(?:SECRET|PASSWORD|TOKEN|CREDENTIAL|_KEY)[A-Z0-9_]*=)(\S+)"),
+    re.compile(r"(?i)(Bearer\s+)(\S+)"),
+    re.compile(r"(?i)(X-Amz-Signature=)([0-9a-f]+)"),
+]
+_REDACTED = "<redacted>"
+
+
+def redact(text):
+    """Scrub secret-shaped substrings, leaving the rest of the command intact."""
+    out = text
+    for pat in _SECRET_PATTERNS:
+        if pat.groups >= 2:
+            out = pat.sub(lambda m: m.group(1) + _REDACTED, out)
+        else:
+            out = pat.sub(_REDACTED, out)
+    return out
+
+
+_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_SUBCMD_TOKEN = re.compile(r"^[A-Za-z][\w-]*$")
+
+
+def normalize_command(cmd):
+    """Reduce a command line to program + subcommand(s); drop args/flags/paths."""
+    toks = cmd.split()
+    while toks and _ENV_ASSIGN.match(toks[0]):
+        toks = toks[1:]
+    kept = []
+    for t in toks:
+        if _SUBCMD_TOKEN.match(t):
+            kept.append(t.lower())
+        else:
+            break
+    return " ".join(kept)
+
+
+def is_ceremony(normalized):
+    return normalized in CEREMONY
+
+
+def find_repeated_sequences(items, n=2, min_count=2, require_distinct=True):
+    """Consecutive n-grams that recur at least min_count times.
+
+    require_distinct drops grams whose every element is the same command
+    (`mv -> mv`, `claude -> claude`) — those are shell noise, not workflows.
+    """
+    counts = {}
+    for i in range(len(items) - n + 1):
+        gram = tuple(items[i:i + n])
+        if require_distinct and len(set(gram)) == 1:
+            continue
+        counts[gram] = counts.get(gram, 0) + 1
+    res = [{"sequence": list(g), "count": c}
+           for g, c in counts.items() if c >= min_count]
+    res.sort(key=lambda r: r["count"], reverse=True)
+    return res
+
+
+# Structural junk that Claude tags as type:user but isn't a real question:
+# slash-command wrappers, local-command output, tool/system scaffolding.
+_NOT_A_PROMPT = re.compile(
+    r"<command-name|<command-message|<local-command|<task-notification|"
+    r"<system-reminder|<bash-input|<bash-stdout|<bash-stderr|"
+    r"\[request interrupted", re.IGNORECASE)
+
+
+def is_real_prompt(text):
+    """True if text looks like a genuine user question, not tool scaffolding."""
+    return not _NOT_A_PROMPT.search(text)
+
+
+def _tokens(text):
+    return set(t for t in re.split(r"[^a-z0-9]+", text.lower()) if t)
+
+
+def lexical_similarity(a, b):
+    """Jaccard over word tokens. 1.0 identical, 0.0 disjoint."""
+    ta, tb = _tokens(a), _tokens(b)
+    if not ta and not tb:
+        return 1.0
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def find_gap_candidates(prompts, threshold=0.6, min_tokens=4, max_tokens=60):
+    """Cluster near-duplicate prompts. Trivial/huge prompts are dropped, and
+    pairs are blocked by shared token so this stays near-linear instead of the
+    O(n^2) cross-product. ponytail: per-token buckets are capped; a hyper-common
+    token won't blow up, at the cost of missing matches that only share stopwords.
+    """
+    cleaned = []  # (prompt, tokens)
+    for p in prompts:
+        toks = _tokens(p)
+        if min_tokens <= len(toks) <= max_tokens:
+            cleaned.append((p, toks))
+
+    index = {}  # token -> [indices into cleaned]
+    for i, (_, toks) in enumerate(cleaned):
+        for t in toks:
+            index.setdefault(t, []).append(i)
+
+    pairs = set()
+    for ids in index.values():
+        if len(ids) > 200:  # too common to discriminate; skip the bucket
+            continue
+        for a in range(len(ids)):
+            for b in range(a + 1, len(ids)):
+                pairs.add((ids[a], ids[b]))
+
+    parent = list(range(len(cleaned)))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    best = {}
+    for i, j in pairs:
+        sim = lexical_similarity(cleaned[i][0], cleaned[j][0])
+        if sim >= threshold:
+            ri, rj = find(i), find(j)
+            if ri != rj:
+                parent[ri] = rj
+            best[find(i)] = max(best.get(find(i), 0.0), sim)
+
+    groups = {}
+    for idx in range(len(cleaned)):
+        groups.setdefault(find(idx), []).append(cleaned[idx][0])
+    return [{"prompts": members, "similarity": round(best.get(root, 0.0), 3)}
+            for root, members in groups.items() if len(members) >= 2]
+
+
+def score_against_skills(sequence, skills):
+    """Coverage in [0,1]: how much of the sequence an existing skill already covers.
+
+    This is a DOWN-RANK signal, not a filter. Candidates are never dropped here;
+    the LLM layer decides using this score.
+    """
+    seq_tokens = set()
+    for cmd in sequence:
+        seq_tokens |= _tokens(cmd)
+    if not seq_tokens:
+        return 0.0
+    best = 0.0
+    for s in skills:
+        skill_tokens = _tokens(s.get("name", "") + " " + s.get("description", ""))
+        overlap = len(seq_tokens & skill_tokens) / len(seq_tokens)
+        best = max(best, overlap)
+    return round(best, 3)
+
+
+_HIST_LINE = re.compile(r"^: (\d+):\d+;(.*)$")
+
+
+def parse_zsh_history(text, since_ts=None):
+    """Parse zsh extended history. ponytail: ignores multi-line continuations."""
+    entries = []
+    for line in text.splitlines():
+        m = _HIST_LINE.match(line)
+        if m:
+            ts, cmd = int(m.group(1)), m.group(2)
+        else:
+            if not line.strip():
+                continue
+            ts, cmd = None, line
+        if since_ts is not None and ts is not None and ts < since_ts:
+            continue
+        entries.append({"ts": ts, "cmd": cmd})
+    return entries
+
+
+# --- transcript + skill-frontmatter readers --------------------------------
+
+def _content_text(message):
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [b.get("text", "") for b in content if isinstance(b, dict)]
+        return " ".join(p for p in parts if p)
+    return ""
+
+
+def extract_user_prompts(transcripts_dir, since_ts=None):
+    prompts = []
+    for jf in sorted(Path(transcripts_dir).rglob("*.jsonl")):
+        if since_ts is not None and jf.stat().st_mtime < since_ts:
+            continue
+        for line in jf.read_text(errors="ignore").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                evt = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            msg = evt.get("message") or {}
+            if evt.get("type") == "user" and msg.get("role") == "user":
+                txt = _content_text(msg).strip()
+                if txt and is_real_prompt(txt):
+                    prompts.append(redact(txt))
+    return prompts
+
+
+_FM_NAME = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
+_FM_DESC = re.compile(r"^description:\s*(.+)$", re.MULTILINE)
+
+
+def load_existing_skills(skills_dir):
+    skills = []
+    for sk in sorted(Path(skills_dir).glob("*/SKILL.md")):
+        text = sk.read_text(errors="ignore")
+        name = _FM_NAME.search(text)
+        desc = _FM_DESC.search(text)
+        skills.append({
+            "name": name.group(1).strip() if name else sk.parent.name,
+            "description": desc.group(1).strip() if desc else "",
+        })
+    return skills
+
+
+def mine(history_file, transcripts_dir, skills_dir, since_ts=None,
+         n=2, min_count=2):
+    skills = load_existing_skills(skills_dir) if skills_dir else []
+
+    workflow_candidates = []
+    if history_file and Path(history_file).exists():
+        entries = parse_zsh_history(
+            Path(history_file).read_text(errors="ignore"), since_ts=since_ts)
+        normalized = []
+        for e in entries:
+            norm = normalize_command(redact(e["cmd"]))
+            if norm and not is_ceremony(norm):
+                normalized.append(norm)
+        for cand in find_repeated_sequences(normalized, n=n, min_count=min_count):
+            cand["coverage"] = score_against_skills(cand["sequence"], skills)
+            cand["source"] = "shell"
+            workflow_candidates.append(cand)
+
+    gap_candidates = []
+    if transcripts_dir and Path(transcripts_dir).exists():
+        prompts = extract_user_prompts(transcripts_dir, since_ts=since_ts)
+        gap_candidates = find_gap_candidates(prompts)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "workflow_candidates": workflow_candidates,
+        "gap_candidates": gap_candidates,
+        "existing_skills": skills,
+    }
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="skill-miner deterministic core")
+    ap.add_argument("--history-file")
+    ap.add_argument("--transcripts-dir")
+    ap.add_argument("--skills-dir")
+    ap.add_argument("--since-ts", type=int, default=None)
+    ap.add_argument("-n", type=int, default=2)
+    ap.add_argument("--min-count", type=int, default=2)
+    ap.add_argument("-o", "--out", required=True)
+    args = ap.parse_args(argv)
+
+    result = mine(args.history_file, args.transcripts_dir, args.skills_dir,
+                  since_ts=args.since_ts, n=args.n, min_count=args.min_count)
+    Path(args.out).write_text(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stow-packages/claude/.claude/skills/skill-miner/test_mine.py
+++ b/stow-packages/claude/.claude/skills/skill-miner/test_mine.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Run: python3 test_mine.py
+
+Tests the deterministic core of skill-miner. No framework, matching the
+test_build_cache.py convention. Redaction is the security-critical path and
+gets the heaviest coverage.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).parent
+sys.path.insert(0, str(HERE))
+MINER = HERE / "mine.py"
+
+import mine  # noqa: E402
+
+
+# --- redaction (security path) ---------------------------------------------
+
+def test_redact_aws_access_key():
+    assert "AKIAIOSFODNN7EXAMPLE" not in mine.redact(
+        "aws s3 ls --profile foo # AKIAIOSFODNN7EXAMPLE")
+
+
+def test_redact_password_flag():
+    out = mine.redact("psql --password hunter2trustno1 -h db")
+    assert "hunter2trustno1" not in out
+    assert "psql" in out  # only the secret is scrubbed, not the whole line
+
+
+def test_redact_secret_env_assignment():
+    out = mine.redact(
+        "export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in out
+
+
+def test_redact_bearer_token():
+    out = mine.redact('curl -H "Authorization: Bearer eyJabc.def.ghijkl"')
+    assert "eyJabc.def.ghijkl" not in out
+
+
+def test_redact_presigned_url_signature():
+    out = mine.redact(
+        "curl 'https://x.s3.amazonaws.com/y?X-Amz-Signature=deadbeefcafe1234'")
+    assert "deadbeefcafe1234" not in out
+
+
+def test_redact_leaves_benign_command_untouched():
+    cmd = 'git commit -m "fix the parser"'
+    assert mine.redact(cmd) == cmd
+
+
+# --- command normalization --------------------------------------------------
+
+def test_normalize_strips_args_keeps_program_and_subcommand():
+    assert mine.normalize_command('git commit -m "x"') == "git commit"
+    assert mine.normalize_command("gh pr view 123 --repo a/b") == "gh pr view"
+
+
+def test_normalize_strips_leading_env_assignment():
+    assert mine.normalize_command("AWS_PROFILE=foo terraform plan") == "terraform plan"
+
+
+def test_normalize_single_token():
+    assert mine.normalize_command("ls -la /tmp") == "ls"
+
+
+# --- ceremony stopword filter ----------------------------------------------
+
+def test_is_ceremony_filters_noise():
+    for c in ["ls", "cd", "pwd", "clear", "git status", "cat"]:
+        assert mine.is_ceremony(c), c
+
+
+def test_is_ceremony_passes_real_work():
+    for c in ["terraform apply", "gh pr create", "kubectl rollout"]:
+        assert not mine.is_ceremony(c), c
+
+
+# --- repeated sequence detection -------------------------------------------
+
+def test_find_repeated_sequences_returns_recurring_bigram():
+    seq = ["terraform plan", "terraform apply",
+           "terraform plan", "terraform apply"]
+    res = mine.find_repeated_sequences(seq, n=2, min_count=2)
+    sequences = [tuple(r["sequence"]) for r in res]
+    assert ("terraform plan", "terraform apply") in sequences
+    hit = next(r for r in res if tuple(r["sequence"]) == ("terraform plan", "terraform apply"))
+    assert hit["count"] == 2
+
+
+def test_find_repeated_sequences_drops_below_threshold():
+    seq = ["a", "b", "c", "d"]
+    assert mine.find_repeated_sequences(seq, n=2, min_count=2) == []
+
+
+# --- lexical similarity + gap detection ------------------------------------
+
+def test_lexical_similarity_bounds():
+    assert mine.lexical_similarity("alpha beta", "alpha beta") == 1.0
+    assert mine.lexical_similarity("alpha beta", "gamma delta") == 0.0
+
+
+def test_find_gap_candidates_clusters_near_duplicates():
+    prompts = [
+        "how do I auth to the perf account",
+        "how to auth to perf account",
+        "what is the capital of france",
+    ]
+    clusters = mine.find_gap_candidates(prompts, threshold=0.5)
+    assert len(clusters) == 1
+    members = clusters[0]["prompts"]
+    assert any("perf account" in p for p in members)
+    assert all("france" not in p for p in members)
+
+
+# --- dedup is DOWN-RANK, not drop ------------------------------------------
+
+def test_score_against_skills_ranks_covered_higher_than_novel():
+    skills = [{"name": "terraform-review",
+               "description": "review terraform plan and apply changes"}]
+    covered = mine.score_against_skills(["terraform plan", "terraform apply"], skills)
+    novel = mine.score_against_skills(["docker build", "docker push"], skills)
+    assert covered > novel
+    # nothing is dropped: both return a real score in [0, 1]
+    assert 0.0 <= novel <= covered <= 1.0
+
+
+# --- zsh history parsing ----------------------------------------------------
+
+def test_parse_zsh_history_extended_format():
+    text = ": 1719230000:0;terraform plan\n: 1719230005:0;terraform apply\n"
+    entries = mine.parse_zsh_history(text)
+    assert [e["cmd"] for e in entries] == ["terraform plan", "terraform apply"]
+    assert entries[0]["ts"] == 1719230000
+
+
+def test_parse_zsh_history_filters_by_watermark():
+    text = ": 1000:0;old cmd\n: 2000:0;new cmd\n"
+    entries = mine.parse_zsh_history(text, since_ts=1500)
+    assert [e["cmd"] for e in entries] == ["new cmd"]
+
+
+# --- end-to-end CLI: emits a schema'd, redacted candidates.json ------------
+
+def test_cli_emits_redacted_candidates_json():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        hist = d / "histfile"
+        hist.write_text(
+            ": 1719230000:0;terraform plan # AKIAIOSFODNN7EXAMPLE\n"
+            ": 1719230005:0;terraform apply\n"
+            ": 1719230100:0;terraform plan\n"
+            ": 1719230105:0;terraform apply\n")
+        tdir = d / "transcripts"
+        tdir.mkdir()
+        (tdir / "s.jsonl").write_text(
+            json.dumps({"type": "user", "message": {"role": "user",
+                        "content": "how do I auth to the perf account"}}) + "\n" +
+            json.dumps({"type": "user", "message": {"role": "user",
+                        "content": "how to auth to perf account"}}) + "\n")
+        sdir = d / "skills"
+        (sdir / "terraform-review").mkdir(parents=True)
+        (sdir / "terraform-review" / "SKILL.md").write_text(
+            "---\nname: terraform-review\n"
+            "description: review terraform plan and apply\n---\n")
+        out = d / "candidates.json"
+        r = subprocess.run(
+            [sys.executable, str(MINER),
+             "--history-file", str(hist),
+             "--transcripts-dir", str(tdir),
+             "--skills-dir", str(sdir),
+             "-o", str(out)],
+            capture_output=True, text=True)
+        assert r.returncode == 0, r.stderr
+        data = json.loads(out.read_text())
+        assert data["schema_version"] >= 1
+        for key in ("workflow_candidates", "gap_candidates", "existing_skills"):
+            assert key in data, key
+        # redaction held end-to-end
+        assert "AKIAIOSFODNN7EXAMPLE" not in out.read_text()
+        # the repeated terraform sequence surfaced
+        seqs = [tuple(c["sequence"]) for c in data["workflow_candidates"]]
+        assert ("terraform plan", "terraform apply") in seqs
+        # gap detection caught the near-duplicate question
+        assert len(data["gap_candidates"]) >= 1
+
+
+def test_is_real_prompt_rejects_scaffolding():
+    for junk in [
+        "<command-name>/exit</command-name>",
+        "<local-command-stdout>Bye!</local-command-stdout>",
+        "<task-notification>\n<task-id>abc</task-id>",
+        "<system-reminder>the user named this session</system-reminder>",
+        "[Request interrupted by user]",
+        "<bash-input>echo test</bash-input>",
+    ]:
+        assert not mine.is_real_prompt(junk), junk
+
+
+def test_is_real_prompt_keeps_genuine_questions():
+    for ok in ["give me the link to the PR",
+               "did you do a code review of the work?"]:
+        assert mine.is_real_prompt(ok), ok
+
+
+def test_find_repeated_sequences_rejects_same_command_repeat():
+    # "mv -> mv" / "claude -> claude" are noise, not workflows
+    assert mine.find_repeated_sequences(["mv", "mv", "mv", "mv"]) == []
+    # a genuine distinct sequence still surfaces
+    res = mine.find_repeated_sequences(
+        ["terraform plan", "terraform apply"] * 2)
+    assert any(tuple(r["sequence"]) == ("terraform plan", "terraform apply")
+               for r in res)
+
+
+def test_extract_user_prompts_windows_by_mtime():
+    import os
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        old = d / "old.jsonl"
+        new = d / "new.jsonl"
+        old.write_text(json.dumps({"type": "user", "message": {
+            "role": "user", "content": "old question about kafka topics"}}) + "\n")
+        new.write_text(json.dumps({"type": "user", "message": {
+            "role": "user", "content": "new question about kafka topics"}}) + "\n")
+        os.utime(old, (1000, 1000))  # ancient
+        prompts = mine.extract_user_prompts(d, since_ts=1_000_000)
+        joined = " ".join(prompts)
+        assert "new question" in joined
+        assert "old question" not in joined
+
+
+def test_find_gap_candidates_filters_trivial_short_prompts():
+    # "yes" / "run it" are noise, not knowledge gaps, even if repeated
+    prompts = ["yes", "yes", "run it", "run it"]
+    assert mine.find_gap_candidates(prompts, threshold=0.5) == []
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"PASS {fn.__name__}")
+    print(f"{len(fns)} tests passed")

--- a/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/start-of-day/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-of-day
 description: This skill should be used when the user asks to "start of day", "SOD", "run start of day", "kick off the day", "start of day routine", or runs "/start-of-day".
-version: 0.29.0
+version: 0.30.0
 argument-hint: "[--unattended]"
 allowed-tools:
   [
@@ -15,7 +15,7 @@ allowed-tools:
 
 # Start-of-Day Skill
 
-Gather the morning signal — open GitHub PRs, open JIRA tickets assigned to you, and Todoist tasks due today + overdue — and write it as three flat sections into today's Obsidian daily note.
+Gather the morning signal — open GitHub PRs, open JIRA tickets assigned to you, and Todoist #Work tasks due today + overdue — and write it as three flat sections into today's Obsidian daily note.
 
 Layout is owned by a deterministic Python render script (`render.py` next to this file), so the model never composes the markdown by hand. The script:
 
@@ -374,11 +374,13 @@ This call is best-effort: if it fails, write `{"error": "<msg>"}` to `/tmp/sod-m
 
    Write the **merged** map to `/tmp/sod-jira.json` as `{"issues": [...]}` — one entry per ticket (assigned + ancestor), each with `key`, `assignedToMe`, and a `fields` object containing `summary, status, priority, issuetype, updated, parent`. The render script reads this shape and builds the forest itself; no traversal logic in the script.
 
-2. **Bash — Todoist:**
+2. **Bash — Todoist (#Work project only):**
 
    ```bash
-   td today --json
+   td task list --filter "(today | overdue) & #Work" --json
    ```
+
+   Scoped to the #Work project so the daily note shows only work tasks, not personal ones. Output shape matches `td today --json` (`{"results": [...]}`), so `render.py` consumes it unchanged.
 
 After all three fetches return (or fail), persist each result to a temp JSON file for Step 3 to consume:
 
@@ -519,6 +521,6 @@ Failures that **do not** halt:
 
 ## Summary
 
-`/start-of-day` fetches open GitHub PRs, assigned open JIRA tickets, and Todoist due-today + overdue tasks in parallel, then writes three flat bulleted sections into today's Obsidian daily note under a `## Start of Day` heading bracketed by `<!-- sod:begin -->` / `<!-- sod:end -->` markers. The write is idempotent (re-running the same day replaces the section). The skill is one-shot and non-interactive: a single confirmation line prints once the note is written, then the skill invokes `/daily-standup` as its final step to append a `## Daily Standup` section to the same daily note.
+`/start-of-day` fetches open GitHub PRs, assigned open JIRA tickets, and Todoist #Work due-today + overdue tasks in parallel, then writes three flat bulleted sections into today's Obsidian daily note under a `## Start of Day` heading bracketed by `<!-- sod:begin -->` / `<!-- sod:end -->` markers. The write is idempotent (re-running the same day replaces the section). The skill is one-shot and non-interactive: a single confirmation line prints once the note is written, then the skill invokes `/daily-standup` as its final step to append a `## Daily Standup` section to the same daily note.
 
 From v0.19.0 the markdown is emitted by `render.py` (Python 3 stdlib) rather than composed by the model — the model writes the three fetch results to JSON files, invokes the script, and splices the script's stdout into the daily note. JIRA parent traversal, PR↔JIRA cross-linking, Potential-to-close, and emoji prefixes were intentionally left out of this baseline; they will be added to the script in subsequent versions.

--- a/stow-packages/claude/.claude/skills/what-next/SKILL.md
+++ b/stow-packages/claude/.claude/skills/what-next/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: what-next
 description: This skill should be used when the user asks "what next", "what-next", "what should I work on", "what's next", or otherwise wants a recommendation for the next piece of work to pick up. Synthesizes across active projects, project logs, the wiki log, and today's daily note to surface a single recommended task plus a triage view of overdue work, open follow-ups, and stale projects.
-version: 0.2.0
+version: 0.3.0
 allowed-tools:
   [
     Bash,
@@ -15,7 +15,7 @@ allowed-tools:
 
 # What-Next Skill
 
-Advisory skill that answers the question **"What should I work on next?"** by reading three sources and synthesizing a recommendation in narrative form. Read-only and terminal-only — no file writes, no daily note mutation. Live JIRA status and GitHub PR status are verified for any candidate before it's recommended, to avoid suggesting work that has already been closed, merged, or moved since `/start-of-day` last refreshed the daily note. Cheap to run multiple times a day.
+Advisory skill that answers the question **"What should I work on next?"** by reading three sources and synthesizing a recommendation in narrative form. Read-only and terminal-only — no file writes, no daily note mutation. Live JIRA status and GitHub PR status are verified for any candidate before it's recommended, to avoid suggesting work that has already been closed, merged, or moved since `/start-of-day` last refreshed the daily note. Any disagreement between the cached daily-note snapshot and live state is flagged explicitly in the output rather than silently corrected for. Cheap to run multiple times a day.
 
 ## Purpose
 
@@ -192,6 +192,8 @@ Verify the live status of every JIRA ticket and GitHub PR you plan to name in th
 
 If verification reveals the item is closed/merged/re-assigned, drop it from the recommendation and pick the next candidate — then verify that one too. Do not print an unverified candidate as a fallback.
 
+**Record cached-vs-live discrepancies.** Whenever live state differs from what the cached snapshot showed — the daily-note JIRA/PR section or the Step 2 JQL result — record the difference for the output's discrepancy section (Step 6). A discrepancy is any of: a ticket whose live status differs from the daily-note status, a ticket present in one source but not the other, a PR that has merged/closed since the snapshot, a PR approval state that changed, or a re-assignment. This is in addition to acting on the discrepancy (dropping a stale candidate, etc.) — the point is to make the staleness visible to the user, not just silently correct for it. If the daily note and live state fully agree for every item named, note that too ("daily note matches live state").
+
 **JIRA ticket verification** — if the candidate references a key like `FANDEVX-1234`, `FESFEAT-5678`, or any `[A-Z]+-\d+` pattern:
 
 - Call `mcp__plugin_fbg-core_atlassian__getJiraIssue` with the key.
@@ -246,8 +248,14 @@ Output goes to the terminal only — no file writes. Use this format:
 ### Stale — worth touching
 - **<Project>** — last log entry <date> (<N days ago>)
 
+### Cached vs live discrepancies
+- **KEY** <jira-url> — daily note said <cached status>, live is <live status>
+- **PR #N** <pr-url> — daily note listed as open, live is MERGED <date>
+- **KEY** <jira-url> — re-assigned to <login> since last snapshot
+
 ### Quick context
 - Daily note: <fresh / N days stale / missing>
+- Cached vs live: <N discrepancies / matches live state>
 - Active projects: <count>
 - Open PRs in daily note: <count>
 - In-progress JIRA tickets: <count>

--- a/stow-packages/zsh/.zshrc
+++ b/stow-packages/zsh/.zshrc
@@ -131,3 +131,7 @@ export PATH="$PATH:/home/ian/.local/bin"
 
 # Added by LM Studio CLI tool (lms)
 export PATH="$PATH:/Users/ian.bartholomew/.lmstudio/bin"
+
+
+# Added by Antigravity CLI installer
+export PATH="/Users/ian.bartholomew/.local/bin:$PATH"


### PR DESCRIPTION
## What
Two commits on this branch (post the merged PR #22):

- **feat(codex): link Claude skills and instructions into Codex** — adds `link-codex.sh`, which symlinks the Claude config into the paths Codex reads:
  - `~/.agents/skills/*` -> the Claude skill source (live, zero drift, same SKILL.md format)
  - `~/.codex/AGENTS.md` -> the committed `AGENTS.md` (a trimmed CLAUDE.md)
  - No-op when the `codex` CLI isn't installed.
- **Adding skills** — skill-miner (with tests), daily-standup rewrite (+tests), start-of-day / what-next tweaks, CLAUDE.md and `.zshrc` updates.

## Why
I use Claude Code as the primary tool; this points Codex at the same config instead of maintaining parallel copies. Codex agent `.toml`s were intentionally dropped (not used).

## Notes
Mixed scope by request: the codex linker and the "Adding skills" work are bundled in one PR.