### PR TITLE
fix(moa): stop council seats timing out, speed up consults, harden signal handling

### DIFF
--- a/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
+++ b/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
@@ -25,7 +25,7 @@ ANTIGRAVITY_MODEL="${COUNCIL_ANTIGRAVITY_MODEL:-}"
 # quota pool). Override via COUNCIL_ANTIGRAVITY_FALLBACK; empty disables the fallback.
 ANTIGRAVITY_FALLBACK="${COUNCIL_ANTIGRAVITY_FALLBACK:-GPT-OSS 120B (Medium)}"
 SONNET_MODEL="${COUNCIL_SONNET_MODEL:-claude-sonnet-4-6}"
-TIMEOUT="${COUNCIL_TIMEOUT:-180}"
+TIMEOUT="${COUNCIL_TIMEOUT:-240}"
 
 case "$TIMEOUT" in
   ''|*[!0-9]*) echo "COUNCIL_TIMEOUT must be a positive integer (got '$TIMEOUT')" >&2; exit 1 ;;
@@ -56,9 +56,13 @@ IFS=',' read -ra MEMBERS <<< "$members_csv"
 member_bin() { case "$1" in codex) echo codex ;; antigravity) echo agy ;; sonnet) echo claude ;; *) echo "" ;; esac; }
 
 missing=""
+seen=""
 for m in "${MEMBERS[@]}"; do
   bin="$(member_bin "$m")"
   [ -n "$bin" ] || { echo "unknown member: '$m' (valid: codex, antigravity, sonnet)" >&2; exit 1; }
+  # Duplicates would run two workers writing the same <member>.out/.exit concurrently.
+  case " $seen " in *" $m "*) echo "duplicate member: '$m'" >&2; exit 1 ;; esac
+  seen="$seen $m"
   command -v "$bin" >/dev/null 2>&1 || missing="$missing $bin"
 done
 [ -z "$missing" ] || { echo "missing required CLI(s):$missing" >&2; exit 1; }
@@ -79,39 +83,52 @@ if [ "$prompt_bytes" -gt 500000 ]; then
   exit 1
 fi
 
+# Print all descendant PIDs of $1, deepest first. Called to snapshot the tree BEFORE any
+# kill: once a process dies its survivors reparent (to init), so walking down from the
+# original parent afterwards can no longer find them. We use `set -m` + group kill is not
+# viable here (the member is double-nested in background, never a process-group leader),
+# and macOS has no `setsid`, so an explicit PID snapshot is the portable option.
+descendants() {
+  local pid="$1" kid
+  for kid in $(pgrep -P "$pid" 2>/dev/null); do descendants "$kid"; echo "$kid"; done
+}
+
 # ponytail: macOS has no `timeout`. Run the command in the background with a watchdog
 # that polls once a second and kills it after TIMEOUT seconds. Polling (vs one long
 # `sleep $secs`) means killing the watchdog on the success path orphans at most a 1s
 # sleep, not a full-timeout one. Returns the command's exit code, or 124 on timeout.
-#
-# On timeout we kill the member's direct children (pkill -P) before the member itself,
-# so a CLI that forked a worker (node/python wrappers) doesn't leave it orphaned. We do
-# NOT use `set -m` + `kill -- -$pid` (the obvious process-group approach): in this
-# script the member is double-nested in background, so it never becomes its own
-# process-group leader and the group-kill silently kills nothing (verified). pkill -P
-# reaps one level of children, which covers the common case; deeper trees are the known
-# ceiling, acceptable since members are read-only and short-lived.
 run_with_timeout() {
   local secs="$1"; shift
   "$@" &
   local cmd_pid=$!
   (
-    local i=0
+    i=0
     while [ "$i" -lt "$secs" ]; do
       kill -0 "$cmd_pid" 2>/dev/null || exit 0
       sleep 1; i=$((i + 1))
     done
-    pkill -TERM -P "$cmd_pid" 2>/dev/null; kill -TERM "$cmd_pid" 2>/dev/null
+    # Snapshot the whole subtree by PID, then TERM, then escalate to KILL. Killing by PID
+    # (not `pkill -P`) means a child that traps TERM and outlives its parent, so it
+    # reparents away, is still reaped by the KILL pass.
+    tree="$(descendants "$cmd_pid") $cmd_pid"
+    kill -TERM $tree 2>/dev/null
     sleep 2
-    pkill -KILL -P "$cmd_pid" 2>/dev/null; kill -KILL "$cmd_pid" 2>/dev/null
+    kill -KILL $tree 2>/dev/null
   ) &
   local watch_pid=$!
   wait "$cmd_pid" 2>/dev/null
   local rc=$?
-  kill "$watch_pid" 2>/dev/null
-  wait "$watch_pid" 2>/dev/null
-  # A kill from our watchdog surfaces as 143 (TERM) or 137 (KILL); report as timeout.
-  if [ "$rc" -eq 143 ] || [ "$rc" -eq 137 ]; then rc=124; fi
+  if [ "$rc" -eq 143 ] || [ "$rc" -eq 137 ]; then
+    # Timeout path: let the watchdog complete its TERM->sleep->KILL escalation before
+    # reaping it. Killing it here (as the success path does) would cut the escalation
+    # short and let a TERM-ignoring child survive. Report the kill as a timeout.
+    wait "$watch_pid" 2>/dev/null
+    rc=124
+  else
+    # Success path: the watchdog is still polling; stop it (orphans at most a 1s sleep).
+    kill "$watch_pid" 2>/dev/null
+    wait "$watch_pid" 2>/dev/null
+  fi
   return "$rc"
 }
 
@@ -123,7 +140,9 @@ run_codex() {
   local out="$out_dir/codex.out"
   local args=(exec --skip-git-repo-check -s read-only -o "$out")
   [ -n "$CODEX_MODEL" ] && args+=(-m "$CODEX_MODEL")
-  args+=("$PROMPT")
+  # `--` ends option parsing so a prompt beginning with a dash is treated as the prompt,
+  # not misread as a codex flag.
+  args+=(-- "$PROMPT")
   # ponytail: </dev/null is load-bearing. Members get the prompt via argv; without
   # closing stdin, claude -p blocks waiting on it and fails under parallel contention.
   run_with_timeout "$TIMEOUT" codex "${args[@]}" >"$out_dir/codex.log" 2>&1 </dev/null
@@ -153,10 +172,36 @@ run_antigravity() {
 
 run_sonnet() {
   local out="$out_dir/sonnet.out"
-  run_with_timeout "$TIMEOUT" claude -p "$PROMPT" --model "$SONNET_MODEL" --permission-mode plan \
+  # No --permission-mode plan: plan mode makes claude explore/plan before answering
+  # (~5x slower, measured 321s vs 61s on a hard prompt), which blows the per-member
+  # timeout so the sonnet seat gets killed and drops out. Read-only is preserved
+  # without it: headless -p can't get interactive approval, so write tools are denied.
+  run_with_timeout "$TIMEOUT" claude -p "$PROMPT" --model "$SONNET_MODEL" \
     >"$out" 2>"$out_dir/sonnet.log" </dev/null
   echo "$?" >"$out_dir/sonnet.exit"
 }
+
+# Tear the whole member subtree down (TERM, brief grace, KILL) without exiting. Used to
+# reap stragglers on an early quorum return and by the interrupt trap below.
+reap_children() {
+  local tree
+  tree="$(descendants $$)"
+  if [ -n "$tree" ]; then
+    kill -TERM $tree 2>/dev/null
+    sleep 1
+    kill -KILL $tree 2>/dev/null
+  fi
+}
+# If the round is interrupted, reap now instead of leaving the CLIs orphaned to be killed
+# one-by-one when their watchdogs finally time out.
+reap_and_exit() {
+  local sig="$1"
+  reap_children
+  trap - INT TERM
+  kill "-$sig" $$ 2>/dev/null
+}
+trap 'reap_and_exit INT' INT
+trap 'reap_and_exit TERM' TERM
 
 for m in "${MEMBERS[@]}"; do
   case "$m" in
@@ -165,7 +210,28 @@ for m in "${MEMBERS[@]}"; do
     sonnet)      run_sonnet & ;;
   esac
 done
-wait
+
+# Optional quorum: proceed as soon as COUNCIL_QUORUM members have a good answer and reap the
+# stragglers, instead of blocking on the slowest. Opt-in (a caller like /moa may set it);
+# default (unset / 0 / >= member count) waits for all, preserving /council's all-opinions
+# semantics. Each member has its own watchdog, so the poll loop is bounded by TIMEOUT.
+quorum="${COUNCIL_QUORUM:-0}"
+case "$quorum" in ''|*[!0-9]*) quorum=0 ;; esac
+if [ "$quorum" -gt 0 ] && [ "$quorum" -lt "${#MEMBERS[@]}" ]; then
+  while :; do
+    ok=0; fin=0
+    for member in "${MEMBERS[@]}"; do
+      [ -f "$out_dir/$member.exit" ] || continue
+      fin=$((fin + 1))
+      [ "$(cat "$out_dir/$member.exit" 2>/dev/null)" = "0" ] && [ -s "$out_dir/$member.out" ] && ok=$((ok + 1))
+    done
+    [ "$ok" -ge "$quorum" ] && break
+    [ "$fin" -ge "${#MEMBERS[@]}" ] && break
+    sleep 0.2
+  done
+  reap_children
+fi
+wait 2>/dev/null
 
 any_ok=1
 for member in "${MEMBERS[@]}"; do

--- a/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
+++ b/stow-packages/claude/.claude/skills/council/scripts/council-round.sh
@@ -66,7 +66,7 @@ for m in "${MEMBERS[@]}"; do
   command -v "$bin" >/dev/null 2>&1 || missing="$missing $bin"
 done
 [ -z "$missing" ] || { echo "missing required CLI(s):$missing" >&2; exit 1; }
-command -v pkill >/dev/null 2>&1 || echo "warning: pkill not found; timed-out members may leave orphaned child processes" >&2
+command -v pgrep >/dev/null 2>&1 || echo "warning: pgrep not found; timed-out members may leave orphaned child processes" >&2
 if [ ! -f "$prompt_file" ]; then
   echo "prompt file not found: $prompt_file" >&2
   exit 1

--- a/stow-packages/claude/.claude/skills/council/scripts/test_council-round.sh
+++ b/stow-packages/claude/.claude/skills/council/scripts/test_council-round.sh
@@ -149,3 +149,145 @@ nofb_manifest="$(PATH="$WORK/aybin:$PATH" COUNCIL_TIMEOUT=10 \
   bash "$HERE/council-round.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/out8" --members antigravity)"
 echo "$nofb_manifest" | grep -q $'antigravity\tfailed' || { echo "FAIL: non-quota failure should stay failed (no fallback)"; echo "$nofb_manifest"; exit 1; }
 echo "PASS: non-quota failures do not trigger the gpt-oss fallback"
+
+# --- regression: the sonnet seat must NOT use --permission-mode plan ---
+# Plan mode makes claude explore/plan before answering (~5x slower: 321s vs 61s on a
+# hard prompt), which blows the per-member timeout so sonnet gets killed and the round
+# degrades to "only antigravity returns". Read-only is preserved without it (headless
+# -p denies write tools). Pin the flag out so it can't silently return.
+grep -v '^[[:space:]]*#' "$HERE/council-round.sh" | grep -q 'permission-mode plan' \
+  && { echo "FAIL: sonnet seat reintroduced --permission-mode plan (causes timeout drop-out)"; exit 1; }
+echo "PASS: sonnet seat does not use plan mode"
+
+# --- regression: a member slower than the timeout is dropped, faster members survive ---
+# The real-world failure shape: one seat over budget, the rest fine, round still succeeds.
+mkdir -p "$WORK/mixbin"
+cat >"$WORK/mixbin/codex" <<EOF
+#!/usr/bin/env bash
+out=""; while [ \$# -gt 0 ]; do case "\$1" in -o) out="\$2"; shift 2 ;; *) shift ;; esac; done
+[ -n "\$out" ] && echo "codex fast answer" >"\$out"; exit 0
+EOF
+# sonnet is the slow one: hangs past the 1s timeout
+cat >"$WORK/mixbin/claude" <<'EOF'
+#!/usr/bin/env bash
+sleep 30
+EOF
+cat >"$WORK/mixbin/agy" <<'EOF'
+#!/usr/bin/env bash
+echo "agy fast answer"; exit 0
+EOF
+chmod +x "$WORK/mixbin/"*
+mix_manifest="$(PATH="$WORK/mixbin:$PATH" COUNCIL_TIMEOUT=1 \
+  bash "$HERE/council-round.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/out9")"
+mix_rc=$?
+[ "$mix_rc" = "0" ] || { echo "FAIL: mixed round should exit 0 (2 fast members ok), got $mix_rc"; echo "$mix_manifest"; exit 1; }
+echo "$mix_manifest" | grep -q $'codex\tok'                || { echo "FAIL: fast codex should be ok"; echo "$mix_manifest"; exit 1; }
+echo "$mix_manifest" | grep -q $'antigravity\tok'          || { echo "FAIL: fast antigravity should be ok"; echo "$mix_manifest"; exit 1; }
+echo "$mix_manifest" | grep -q $'sonnet\tfailed(timeout)'  || { echo "FAIL: slow sonnet should be failed(timeout)"; echo "$mix_manifest"; exit 1; }
+echo "PASS: a slow member is dropped as timeout while faster members survive"
+
+# --- regression: duplicate --members is rejected (would race two writers on one file) ---
+PATH="$WORK/bin:$PATH" bash "$HERE/council-round.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/outdup" --members codex,codex >/dev/null 2>&1 \
+  && { echo "FAIL: duplicate member should be rejected"; exit 1; }
+echo "PASS: duplicate --members rejected"
+
+# --- regression: a prompt beginning with a dash reaches codex as the prompt, not a flag ---
+# council-round must pass `-- "$PROMPT"` so codex option-parsing can't swallow it.
+mkdir -p "$WORK/c5bin"
+cat >"$WORK/c5bin/codex" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$WORK/cargs"
+out=""; while [ \$# -gt 0 ]; do case "\$1" in -o) out="\$2"; shift 2 ;; *) shift ;; esac; done
+[ -n "\$out" ] && echo "ok" >"\$out"; exit 0
+EOF
+chmod +x "$WORK/c5bin/codex"
+printf -- '-v danger' > "$WORK/dashprompt.txt"
+PATH="$WORK/c5bin:$PATH" COUNCIL_TIMEOUT=10 bash "$HERE/council-round.sh" \
+  --prompt-file "$WORK/dashprompt.txt" --out-dir "$WORK/outdash" --members codex >/dev/null 2>&1
+grep -A1 '^--$' "$WORK/cargs" | grep -qx -- '-v danger' \
+  || { echo "FAIL: dash-prompt not isolated after -- (got:)"; cat "$WORK/cargs"; exit 1; }
+echo "PASS: dash-leading prompt is isolated after -- for codex"
+
+# --- regression (C3): a TERM-ignoring child is still SIGKILLed after timeout ---
+# The watchdog must snapshot the process tree and escalate to KILL; if it only sends TERM
+# (which the child traps away) or is cut off before escalating, the child leaks.
+mkdir -p "$WORK/ignbin"
+cat >"$WORK/ignbin/agy" <<EOF
+#!/usr/bin/env bash
+( trap '' TERM; while :; do sleep 0.2; done ) &
+echo \$! > "$WORK/ign.childpid"   # \$! (not \$BASHPID: absent in macOS bash 3.2)
+wait
+EOF
+chmod +x "$WORK/ignbin/agy"
+PATH="$WORK/ignbin:$PATH" COUNCIL_TIMEOUT=1 bash "$HERE/council-round.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/outign" --members antigravity >/dev/null 2>&1
+sleep 3   # allow TERM(trapped) -> sleep 2 -> KILL escalation to run
+ignpid="$(cat "$WORK/ign.childpid" 2>/dev/null)"
+if [ -n "$ignpid" ] && kill -0 "$ignpid" 2>/dev/null; then
+  kill -KILL "$ignpid" 2>/dev/null   # don't leak the process onto the test host
+  echo "FAIL: TERM-ignoring child survived the watchdog (pid $ignpid)"; exit 1
+fi
+echo "PASS: TERM-ignoring child is escalated to SIGKILL"
+
+# --- regression (C2): SIGTERM to the round reaps its members promptly (no orphan wait) ---
+# Without a trap, interrupting the script orphans the member CLIs; they only die when their
+# watchdog fires at the full timeout. The trap must tear the subtree down immediately.
+mkdir -p "$WORK/trapbin"
+for c in codex agy claude; do
+  cat >"$WORK/trapbin/$c" <<EOF
+#!/usr/bin/env bash
+echo \$\$ > "$WORK/${c}.pid"
+sleep 30
+EOF
+done
+chmod +x "$WORK/trapbin/"*
+rm -f "$WORK/codex.pid" "$WORK/agy.pid" "$WORK/claude.pid"
+PATH="$WORK/trapbin:$PATH" COUNCIL_TIMEOUT=30 bash "$HERE/council-round.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/outtrap" >/dev/null 2>&1 &
+crpid=$!
+for i in $(seq 1 50); do
+  [ -f "$WORK/codex.pid" ] && [ -f "$WORK/agy.pid" ] && [ -f "$WORK/claude.pid" ] && break; sleep 0.1
+done
+kill -TERM "$crpid" 2>/dev/null
+sleep 3
+leaked=""
+for c in codex agy claude; do p=$(cat "$WORK/${c}.pid" 2>/dev/null); [ -n "$p" ] && kill -0 "$p" 2>/dev/null && leaked="$leaked $c($p)"; done
+if [ -n "$leaked" ]; then
+  for c in codex agy claude; do p=$(cat "$WORK/${c}.pid" 2>/dev/null); [ -n "$p" ] && kill -KILL "$p" 2>/dev/null; done
+  echo "FAIL: members leaked after SIGTERM to the script:$leaked"; exit 1
+fi
+echo "PASS: SIGTERM to the round reaps its members promptly"
+
+# --- S4: COUNCIL_QUORUM returns on quorum without blocking on the slow member ---
+mkdir -p "$WORK/qbin"
+cat >"$WORK/qbin/codex" <<EOF
+#!/usr/bin/env bash
+out=""; while [ \$# -gt 0 ]; do case "\$1" in -o) out="\$2"; shift 2 ;; *) shift ;; esac; done
+[ -n "\$out" ] && echo "codex quick" >"\$out"; exit 0
+EOF
+cat >"$WORK/qbin/agy" <<'EOF'
+#!/usr/bin/env bash
+echo "agy quick"; exit 0
+EOF
+cat >"$WORK/qbin/claude" <<'EOF'
+#!/usr/bin/env bash
+sleep 30
+EOF
+chmod +x "$WORK/qbin/"*
+q_start=$SECONDS
+q_manifest="$(PATH="$WORK/qbin:$PATH" COUNCIL_TIMEOUT=30 COUNCIL_QUORUM=2 \
+  bash "$HERE/council-round.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/outq")"
+q_el=$((SECONDS - q_start))
+[ "$q_el" -lt 10 ] || { echo "FAIL: quorum should return fast (took ${q_el}s; slow member not reaped)"; echo "$q_manifest"; exit 1; }
+echo "$q_manifest" | grep -q $'codex\tok'       || { echo "FAIL: codex should be ok"; echo "$q_manifest"; exit 1; }
+echo "$q_manifest" | grep -q $'antigravity\tok' || { echo "FAIL: antigravity should be ok"; echo "$q_manifest"; exit 1; }
+echo "$q_manifest" | grep -q $'sonnet\tok'      && { echo "FAIL: slow sonnet must not be ok under quorum=2"; echo "$q_manifest"; exit 1; }
+echo "PASS: COUNCIL_QUORUM returns on quorum and reaps the slow member"
+
+# default (no COUNCIL_QUORUM) still waits for all (regression guard for /council semantics)
+def_manifest="$(PATH="$WORK/bin:$PATH" COUNCIL_TIMEOUT=10 \
+  bash "$HERE/council-round.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/outdef")"
+echo "$def_manifest" | grep -q $'codex\tok' && echo "$def_manifest" | grep -q $'sonnet\tok' \
+  || { echo "FAIL: default (no quorum) should collect all available members"; echo "$def_manifest"; exit 1; }
+echo "PASS: default still waits for all members (quorum off)"

--- a/stow-packages/claude/.claude/skills/moa/SKILL.md
+++ b/stow-packages/claude/.claude/skills/moa/SKILL.md
@@ -51,21 +51,26 @@ directly. Only decision points trigger a consult.
 
 Write the sub-question plus the **minimal** relevant context (paths, constraints, the exact
 choice) to a prompt file with the **Write tool** (never a bash heredoc: arbitrary text and
-terminator collisions). If the sub-question is about repo code, say so and cite the files
-so proposers read them. Then:
+terminator collisions). If the sub-question is about repo code, **inline the relevant
+excerpts** (the specific functions, config, or lines) into the prompt. Do not tell proposers
+to go read the files themselves: the heavyweight CLIs (codex, `claude -p`) turn that into a
+multi-round agentic file crawl that routinely blows the per-member timeout, so only the
+lightweight seat answers and the consult silently degrades. You are already looking at the
+code; paste what matters. End the prompt with a length cap so proposers stay useful to an
+aggregator: "lead with your recommendation, stay under ~250 words, no preamble." Then:
 
 ```bash
 OUT_DIR="$(mktemp -d /tmp/moa-consult.XXXXXX)"
 bash ~/.claude/skills/moa/scripts/moa-consult.sh \
-  --prompt-file "$PROMPT_FILE" --out-dir "$OUT_DIR" --layers 2
+  --prompt-file "$PROMPT_FILE" --out-dir "$OUT_DIR"
 ```
 
 `moa-consult.sh` runs the proposer layers deterministically: layer 1 fans the question out
 to the trio in parallel; each later layer feeds the prior layer's proposals back to the
 proposers to refine (Together-style). It prints the path to `moa-final.md` (last line) and
-handles timeouts, quorum, and degradation. `--layers 2` is the default; use `--layers 1`
-for a cheaper single fan-out, `--layers 3` only for a genuinely hard fork. `--members`
-overrides the trio if you must.
+handles timeouts, quorum, and degradation. A single fan-out (`--layers 1`) is the default and
+the right choice for almost every consult; add `--layers 2` (or `3`) only at a genuinely hard
+fork where cross-refinement earns its serial cost. `--members` overrides the trio if you must.
 
 Read `moa-final.md`: the refined proposals from the last successful layer, labeled per
 member, with a per-layer status summary. If a whole layer failed it falls back to the last
@@ -88,24 +93,35 @@ command, the file. Continue the task to the next step or decision point.
 
 Reuse the council transcript pattern. Replace `SUBQ` with the actual sub-question.
 
+**Shell variables do not survive between separate Bash tool calls here**, so this block
+must `echo` the transcript path and you then use that **literal** path (and the literal
+`OUT_DIR`/prompt-file paths from step 3) in the following Write and cleanup, never a `$VAR`
+from an earlier call. Run this as one block:
+
 ```bash
 SUBQ='...the sub-question...'
 if ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
   DEST="$ROOT/.claude/moa"
   IGN="$ROOT/.gitignore"
-  grep -qxF '.claude/moa/' "$IGN" 2>/dev/null || printf '.claude/moa/\n' >>"$IGN"
+  # Append the ignore rule on its own line even if .gitignore lacks a trailing newline
+  # (otherwise it glues onto the last entry and the grep guard never matches again).
+  if ! grep -qxF '.claude/moa/' "$IGN" 2>/dev/null; then
+    [ -s "$IGN" ] && [ -n "$(tail -c1 "$IGN" 2>/dev/null)" ] && printf '\n' >>"$IGN"
+    printf '.claude/moa/\n' >>"$IGN"
+  fi
 else
   DEST="$HOME/.claude/moa-logs"
 fi
 mkdir -p "$DEST"
 SLUG="$(printf '%s' "$SUBQ" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | cut -c1-50 | sed 's/-$//')"
-TRANSCRIPT="$DEST/$(date +%Y%m%d-%H%M%S)-$$-$SLUG.md"
+echo "$DEST/$(date +%Y%m%d-%H%M%S)-$$-$SLUG.md"   # <- copy this literal path
 ```
 
-Write to `$TRANSCRIPT` (Write tool): the sub-question, the contents of `moa-final.md`, and
-your aggregation + decision. **Only after** confirming it wrote (`[ -s "$TRANSCRIPT" ]`),
-clean up: `rm -rf "$OUT_DIR" "$PROMPT_FILE"`. If the write failed, leave `$OUT_DIR` in place
-(it holds the only copy of the proposals) and tell the user where it is.
+Write to that **literal** path (Write tool): the sub-question, the contents of
+`moa-final.md`, and your aggregation + decision. **Only after** confirming it wrote
+(`[ -s "<that literal path>" ]`), clean up with the **literal** paths from step 3:
+`rm -rf "<the /tmp/moa-consult.XXXX dir>" "<the prompt file>"`. If the write failed, leave the
+`OUT_DIR` in place (it holds the only copy of the proposals) and tell the user where it is.
 
 ### 6. Soft consult budget
 

--- a/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
@@ -94,7 +94,8 @@ for i in $(seq 1 "$layers"); do
     --members "$members" >"$manifest" 2>"$out_dir/layer$i.log"
   round_rc=$?
 
-  ok_count="$(grep -c $'\tok\t' "$manifest" 2>/dev/null || echo 0)"
+  # grep -c prints "0" and exits 1 on no match, so a `|| echo 0` fallback would double-print.
+  ok_count="$(grep -c $'\tok\t' "$manifest" 2>/dev/null)"; ok_count="${ok_count:-0}"
   layer_summaries+=("layer$i: rc=$round_rc, ok=$ok_count")
 
   if [ "$round_rc" -eq 0 ] && [ "$ok_count" -gt 0 ]; then

--- a/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
@@ -18,7 +18,10 @@ COUNCIL_ROUND="${MOA_COUNCIL_ROUND:-$HOME/.claude/skills/council/scripts/council
 
 prompt_file=""
 out_dir=""
-layers=2
+# Default to a single fan-out: layers run serially, so each extra layer ~doubles
+# wall-clock. The aggregator synthesizes fine from one round; opt into 2+ only at a
+# genuinely hard fork.
+layers=1
 members="codex,antigravity,sonnet"
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -57,7 +60,13 @@ proposals_from_manifest() {
   done <"$manifest"
 }
 
-REFINE_INSTRUCTION='Below are candidate responses from other models to the same query. Use the strongest points, correct any errors you find, and produce an improved, self-contained response. Do not merely copy one of them.'
+REFINE_INSTRUCTION='Below are candidate responses from other models to the same query. Use the strongest points, correct any errors you find, and produce an improved, self-contained response. Do not merely copy one of them. Keep it tight: lead with your recommendation and stay under ~250 words, no preamble.'
+
+# Early-return once a quorum of proposers answer, rather than blocking each layer on the
+# slowest CLI. The aggregator synthesizes fine from a quorum and MoA degrades gracefully,
+# so trading the slowest seat for speed is the right default here. Override to wait for all
+# with COUNCIL_QUORUM=0 (or =3).
+export COUNCIL_QUORUM="${COUNCIL_QUORUM:-2}"
 
 last_good_dir=""
 last_good_manifest=""

--- a/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/moa-consult.sh
@@ -101,8 +101,11 @@ for i in $(seq 1 "$layers"); do
     last_good_dir="$layer_dir"
     last_good_manifest="$manifest"
   else
-    # Whole layer failed: can't refine further. Keep the last good layer as final.
-    echo "moa: layer $i produced no answers (rc=$round_rc); using layer output up to $((i-1))" >&2
+    # Whole layer failed: can't refine further. Keep the last good layer as final. Surface
+    # the actual cause (missing CLI, bad config, all timed out) that council-round wrote to
+    # the layer log, instead of only a generic "no answers".
+    reason="$(tail -n 3 "$out_dir/layer$i.log" 2>/dev/null | tr '\n' ' ' | sed 's/  */ /g; s/^ *//; s/ *$//')"
+    echo "moa: layer $i produced no answers (rc=$round_rc)${reason:+: $reason}; using layer output up to $((i-1))" >&2
     break
   fi
 done
@@ -113,6 +116,13 @@ if [ -z "$last_good_dir" ]; then
     printf '# MoA consult: all layers failed\n\n'
     printf 'No proposer produced an answer. Per-layer status:\n\n'
     printf -- '- %s\n' "${layer_summaries[@]}"
+    printf '\nWhy the layers failed (council-round output):\n\n'
+    for lg in "$out_dir"/layer*.log; do
+      [ -s "$lg" ] || continue
+      printf '### %s\n\n```\n' "$(basename "$lg")"
+      tail -n 10 "$lg"
+      printf '```\n\n'
+    done
   } >"$final"
   echo "$final" # still tell the caller where the (empty) result is
   exit 1

--- a/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
@@ -109,6 +109,9 @@ PATH="$WORK/bin4:$PATH" bash "$HERE/moa-consult.sh" \
   --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o4" --layers 2 >/dev/null \
   && fail "all-fail should exit non-zero"
 grep -q "all layers failed" "$WORK/o4/moa-final.md" || fail "moa-final should report total failure"
+# `grep -c` prints "0" AND exits 1 on no match, so a `|| echo 0` fallback double-appends,
+# corrupting the per-layer summary bullet with a stray "0" line.
+grep -qxF '0' "$WORK/o4/moa-final.md" && fail "corrupted ok_count: stray '0' line in summary"
 echo "PASS: total failure exits 1 and is reported"
 
 # --- case 5: bad --layers rejected ---

--- a/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
@@ -52,6 +52,7 @@ grep -q "codex refined" "$WORK/o1/layer2/codex.out"  || fail "layer2 codex shoul
 
 # the refinement prompt must carry the instruction AND layer-1's proposals
 grep -q "candidate responses" "$WORK/o1/layer2.prompt" || fail "layer2 prompt missing refine instruction"
+grep -qi "words"             "$WORK/o1/layer2.prompt" || fail "refine prompt missing conciseness cap (output-size lever)"
 grep -q "codex layer1"        "$WORK/o1/layer2.prompt" || fail "layer2 prompt missing codex layer1 proposal"
 grep -q "sonnet layer1"       "$WORK/o1/layer2.prompt" || fail "layer2 prompt missing sonnet layer1 proposal"
 
@@ -68,6 +69,15 @@ PATH="$WORK/bin:$PATH" bash "$HERE/moa-consult.sh" \
 [ ! -d "$WORK/o2/layer2" ]         || fail "layers=1 should not create layer2"
 grep -q "codex layer1" "$WORK/o2/moa-final.md" || fail "layers=1 moa-final missing codex answer"
 echo "PASS: layers=1 is a single council fan-out"
+
+# --- case 2b: the DEFAULT (no --layers) is a single fan-out ---
+# Serial layers double wall-clock; one fan-out is the fast default and the aggregator
+# synthesizes fine from it. Guards the default against silently regressing back to 2.
+PATH="$WORK/bin:$PATH" bash "$HERE/moa-consult.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o2b" >/dev/null \
+  || fail "default layers should exit 0"
+[ ! -d "$WORK/o2b/layer2" ] || fail "default should be a single layer (no layer2)"
+echo "PASS: default is a single fan-out (layers=1)"
 
 # --- case 3: a layer that fails after a good one falls back to the last good layer ---
 # codex here fails ONLY on the refinement round; sonnet always fails -> layer2 has no ok.
@@ -107,5 +117,30 @@ bash "$HERE/moa-consult.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o5
 bash "$HERE/moa-consult.sh" --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o6" --layers abc >/dev/null 2>&1 \
   && fail "--layers abc should be rejected"
 echo "PASS: invalid --layers rejected"
+
+# --- case 6: default quorum makes a layer return without blocking on the slowest seat ---
+# Two fast proposers + one that hangs; moa should not wait out the slow seat's timeout.
+mkdir -p "$WORK/qbin"
+cat >"$WORK/qbin/codex" <<'EOF'
+#!/usr/bin/env bash
+out=""; while [ $# -gt 0 ]; do case "$1" in -o) out="$2"; shift 2 ;; *) shift ;; esac; done
+[ -n "$out" ] && echo "codex quick" >"$out"; exit 0
+EOF
+cat >"$WORK/qbin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "sonnet quick"; exit 0
+EOF
+cat >"$WORK/qbin/agy" <<'EOF'
+#!/usr/bin/env bash
+sleep 30
+EOF
+chmod +x "$WORK/qbin/"*
+q_start=$SECONDS
+PATH="$WORK/qbin:$PATH" COUNCIL_TIMEOUT=30 bash "$HERE/moa-consult.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/oq" >/dev/null 2>&1 || fail "quorum consult should exit 0"
+q_el=$((SECONDS - q_start))
+[ "$q_el" -lt 10 ] || fail "moa should return on quorum, not wait the slow seat (took ${q_el}s)"
+grep -q "codex quick" "$WORK/oq/moa-final.md" || fail "quorum consult missing a fast proposal"
+echo "PASS: default quorum returns without blocking on the slow seat"
 
 echo "ALL PASS"

--- a/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
+++ b/stow-packages/claude/.claude/skills/moa/scripts/test_moa-consult.sh
@@ -143,4 +143,14 @@ q_el=$((SECONDS - q_start))
 grep -q "codex quick" "$WORK/oq/moa-final.md" || fail "quorum consult missing a fast proposal"
 echo "PASS: default quorum returns without blocking on the slow seat"
 
+# --- case 7 (C6): the real failure cause is surfaced, not hidden in the layer log ---
+# COUNCIL_TIMEOUT=0 makes council-round exit with a specific message; moa must surface it
+# in moa-final.md rather than only reporting a generic "no answers".
+PATH="$WORK/bin:$PATH" COUNCIL_TIMEOUT=0 bash "$HERE/moa-consult.sh" \
+  --prompt-file "$WORK/prompt.txt" --out-dir "$WORK/o7" >/dev/null 2>&1 \
+  && fail "COUNCIL_TIMEOUT=0 should make the consult fail"
+grep -qi "COUNCIL_TIMEOUT must be" "$WORK/o7/moa-final.md" \
+  || fail "all-failed final should surface council-round's real error, not just 'no answers'"
+echo "PASS: real failure cause is surfaced in moa-final.md"
+
 echo "ALL PASS"


### PR DESCRIPTION
## Why

The `/moa` (and shared `/council`, `/consensus`) skill degraded to "only antigravity returns results". Root cause: the sonnet seat ran `claude -p --permission-mode plan`; plan mode is ~5x slower (measured 321s vs 61s on a hard prompt) and blew the per-member timeout, so it (and often codex) were killed and dropped from the manifest. This branch fixes that, then works down an adversarial review of the skill for speed and robustness.

## What

Bug fix
- Drop `--permission-mode plan` from the sonnet seat; read-only is preserved (headless `claude -p` denies write tools, verified). Raise the default per-member timeout to 240s.

Speed
- Default MoA to a single fan-out (`--layers 1`); serial layers doubled wall-clock.
- Inline file context in the skill instead of asking proposers to read files, which turned the heavyweight CLIs into a slow agentic crawl that timed out (this reproduced the failure live during review).
- Cap proposer output; add opt-in `COUNCIL_QUORUM` early-return (MoA defaults to 2, `/council` stays wait-for-all to keep all opinions).

Robustness (`council-round.sh`)
- Snapshot the process tree by PID so a SIGTERM-ignoring child is still SIGKILLed (survives reparenting).
- INT/TERM trap reaps the member subtree on interrupt instead of orphaning CLIs until timeout.
- Reject duplicate `--members`; pass the codex prompt after `--` so a dash-leading prompt isn't parsed as a flag.
- Fix the skill's cleanup (shell vars don't persist between bash tool calls) and the `.gitignore` append (missing-newline glue).
- Surface the real failure cause in `moa-final.md` instead of a generic "no answers".
- Pre-push review fixes: `grep -c` double-count corrupting the summary bullet; stale `pkill` preflight check now `pgrep`.

## Not done
- Direct-API Claude seat: blocked (no `ANTHROPIC_API_KEY`; the CLI uses subscription OAuth) and the payoff is now marginal since boot/file-crawl costs are already removed.

## Testing
- `test_council-round.sh`: 15/15. `test_moa-consult.sh`: 8/8. Both scripts shellcheck-clean.
- Real end-to-end smoke: MoA consult returned in ~9s with quorum active; a transient codex failure did not sink the round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
