### PR TITLE
feat(skills): alert-noise-report skill + weekly end-of-day integration

### DIFF
--- a/stow-packages/claude/.claude/skills/alert-noise-report/SKILL.md
+++ b/stow-packages/claude/.claude/skills/alert-noise-report/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: alert-noise-report
+description: Use when the user asks for an alert noise report, "which alerts are noisy", "alert noise", "/alert-noise-report", or as a weekly step in /end-of-day. Covers Datadog alerts routed to #fes-platform-alerts, noise ranking, flap counts, trends over time, and the human diagnosis threads.
+---
+
+# Alert Noise Report
+
+Digest of #fes-platform-alerts (C09HTMY4SP3): which Datadog monitors are noisy,
+which flap, how they trend week over week, and what humans said about them.
+
+Storage model (Obsidian Bases, not a separate database):
+
+- Each run writes one dated report NOTE to `output/reports/alert-noise/<run-date>.md`,
+  with the week's summary metrics in frontmatter and the noise ranking plus human
+  threads in the body. The notes ARE the store.
+- `output/reports/alert-noise/alert-noise.base` renders those notes as a table so
+  trends read down the columns as reports accumulate.
+- `wiki/company/fes-platform-alert-noise.md` is the synthesis: it embeds the base
+  and carries the chronic-offenders list.
+
+`scripts/alert_noise.py` parses Slack and computes one week's numbers. The LLM
+fetches pages, reads threads, and writes notes. Requires the Bases core plugin
+(enabled in this vault).
+
+## Steps
+
+### 1. Read the channel into page files (LLM)
+
+Call `mcp__claude_ai_Slack__slack_read_channel` with `channel_id` C09HTMY4SP3,
+`response_format` `detailed` (concise strips the attachment content),
+`oldest` = now minus 7 days (`date -v-7d +%s`), `limit` 100.
+
+Paginate with `latest` boundaries, NOT the returned cursor (cursors reset when
+combined with `oldest`). For each next page set `latest` to the oldest
+`Message TS` seen so far minus a tiny epsilon. Stop when `pagination_info` says
+no more messages. At limit 100 a detailed page usually exceeds the tool-result
+token cap and the harness saves it to a `tool-results/...txt` path; feed those
+paths to `extract` in step 2.
+
+### 2. Extract events (script)
+
+```bash
+python3 <skill-dir>/scripts/alert_noise.py extract <page-file>... > <scratchpad>/events.tsv
+```
+
+Spot-check the TSV head/tail. If a monitor family shows `env: unknown`, extend
+`env_of` in the script rather than hand-editing rows. If a small final page came
+back inline (not saved), hand-write a supplemental TSV for those events using the
+same normalization the script applies, and `cat` it in.
+
+### 3. Collect human signal (LLM)
+
+Note every human (non-bot) message and any Datadog message with thread replies.
+Read threads with `slack_read_thread` when they carry diagnosis or decisions.
+Capture date, author, one-line gist, and resolution (mute / fix / ongoing).
+
+### 4. Compute metrics and ranking (script)
+
+```bash
+python3 <skill-dir>/scripts/alert_noise.py report <scratchpad>/events.tsv
+```
+
+Prints a frontmatter metrics block and the noise-ranking table.
+
+### 5. Write the dated report note (LLM)
+
+Write `output/reports/alert-noise/<run-date>.md`. Frontmatter MUST include, so the
+base picks them up: `type: alert-noise-report`, `window_start`, `window_end`,
+`run_date` (all YYYY-MM-DD), and the metrics from step 4 (`total_events`,
+`total_triggers`, `total_flaps`, `prod_triggers`, `noisiest_monitor`,
+`noisiest_env`). Body: the ranking table, the human threads from step 3, and a
+2-4 sentence Reading that calls out prod events explicitly and what deserves a
+ticket or a mute-with-reason.
+
+If `output/reports/alert-noise/alert-noise.base` does not exist, create it (see
+the committed copy for the schema: filter `type == "alert-noise-report"`, one
+table view sorted by `run_date` DESC).
+
+### 6. Update the wiki synthesis (LLM)
+
+In `wiki/company/fes-platform-alert-noise.md`: update the Chronic offenders list
+(carry entries forward, mark resolved ones), bump `last_compiled`. The trend
+table updates itself from the base, no manual edit needed. If the page is
+missing, create it (domain `[fanatics, observability]`) and add it to
+`wiki/_indexes/fanatics.md` and `wiki/_indexes/observability.md`.
+
+### 7. Log
+
+Append a `compile` entry to `wiki/_log.md`.
+
+## Backfill (multiple past weeks at once)
+
+To seed history, fetch a wide range and split it into weekly notes:
+
+1. Paginate the whole range with `latest`-boundary pagination (oldest = range
+   start epoch), collecting every saved page path. For a long range this is many
+   pages; delegate the fetch to a subagent so the dumps stay out of context.
+2. `extract` all page files into one TSV (it dedupes across pages).
+3. Slice per week and run `report` on each slice, using fixed midnight-Thursday
+   windows `[Thu 00:00, next Thu 00:00)` so every week is the same shape:
+   `awk -F'\t' -v lo=<start> -v hi=<end> '($1+0)>=lo && ($1+0)<hi' all.tsv`.
+4. Assemble one note per week (frontmatter metrics + ranking + threads + reading).
+
+Gotcha: the Bash tool here runs zsh (1-based arrays); do not loop bash-style
+`${arr[$i]}` from 0, use explicit values or a Python helper for the slicing.
+
+## Caveats
+
+- The channel only shows what routed to `@slack-fes-platform-alerts`; for
+  disputed counts, verify against Datadog monitor events via the Datadog MCP.
+- The report notes are the durable record (Slack history ages out), keep them
+  committed. There is no separate DB to back up.
+- Mutes happen ad hoc (a bare "muted for 2 weeks" reply); tie each mute to the
+  alert immediately above it and record which monitor was muted.

--- a/stow-packages/claude/.claude/skills/alert-noise-report/SKILL.md
+++ b/stow-packages/claude/.claude/skills/alert-noise-report/SKILL.md
@@ -24,20 +24,39 @@ fetches pages, reads threads, and writes notes. Requires the Bases core plugin
 
 ## Steps
 
-### 1. Read the channel into page files (LLM)
+The default job is catch-up: generate a note for every completed week that does
+not have one yet. A manual run and the scheduled `/end-of-day` step share steps
+1-5 and 7; they differ only at step 6 (wiki synthesis), which is interactive-only.
+
+### 1. Pick target weeks (script)
+
+```bash
+python3 <skill-dir>/scripts/alert_noise.py pending output/reports/alert-noise
+```
+
+Each line is a completed Thursday-week with no note yet:
+`wend  wstart  margin_oldest  window_start  window_end` (last three are epochs).
+No lines means nothing to do: report `nothing-to-do` and stop. Otherwise take the
+union fetch range: `oldest` = the smallest `margin_oldest`, newest = the largest
+`window_end`. `margin_oldest` is `window_start - 24h`; that overlap is what keeps
+boundary events from being clipped (a fetch that starts exactly at the window
+start loses the window's first alerts, which is how an earlier run undercounted a
+week by 21 events).
+
+### 2. Fetch the union range into page files (LLM)
 
 Call `mcp__claude_ai_Slack__slack_read_channel` with `channel_id` C09HTMY4SP3,
 `response_format` `detailed` (concise strips the attachment content),
-`oldest` = now minus 7 days (`date -v-7d +%s`), `limit` 100.
+`oldest` = the union `margin_oldest`, `limit` 100.
 
 Paginate with `latest` boundaries, NOT the returned cursor (cursors reset when
 combined with `oldest`). For each next page set `latest` to the oldest
 `Message TS` seen so far minus a tiny epsilon. Stop when `pagination_info` says
 no more messages. At limit 100 a detailed page usually exceeds the tool-result
 token cap and the harness saves it to a `tool-results/...txt` path; feed those
-paths to `extract` in step 2.
+paths to `extract`.
 
-### 2. Extract events (script)
+### 3. Extract events (script)
 
 ```bash
 python3 <skill-dir>/scripts/alert_noise.py extract <page-file>... > <scratchpad>/events.tsv
@@ -48,35 +67,35 @@ Spot-check the TSV head/tail. If a monitor family shows `env: unknown`, extend
 back inline (not saved), hand-write a supplemental TSV for those events using the
 same normalization the script applies, and `cat` it in.
 
-### 3. Collect human signal (LLM)
+### 4. Collect human signal (LLM)
 
-Note every human (non-bot) message and any Datadog message with thread replies.
-Read threads with `slack_read_thread` when they carry diagnosis or decisions.
-Capture date, author, one-line gist, and resolution (mute / fix / ongoing).
+Within the target window(s), note every human (non-bot) message and any Datadog
+message with thread replies. Read threads with `slack_read_thread` when they
+carry diagnosis or decisions. Capture date, author, one-line gist, and resolution
+(mute / fix / ongoing).
 
-### 4. Compute metrics and ranking (script)
+### 5. Per target week: slice, compute, write the note (script + LLM)
+
+For each line from step 1, slice the exact half-open window and compute metrics:
 
 ```bash
-python3 <skill-dir>/scripts/alert_noise.py report <scratchpad>/events.tsv
+awk -F'\t' -v lo=<window_start> -v hi=<window_end> '($1+0)>=lo && ($1+0)<hi' \
+  <scratchpad>/events.tsv > <scratchpad>/week.tsv
+python3 <skill-dir>/scripts/alert_noise.py report <scratchpad>/week.tsv
 ```
 
-Prints a frontmatter metrics block and the noise-ranking table.
-
-### 5. Write the dated report note (LLM)
-
-Write `output/reports/alert-noise/<run-date>.md`. Frontmatter MUST include, so the
-base picks them up: `type: alert-noise-report`, `window_start`, `window_end`,
-`run_date` (all YYYY-MM-DD), and the metrics from step 4 (`total_events`,
+Write `output/reports/alert-noise/<wend>.md`. Frontmatter MUST include (so the
+base picks them up): `type: alert-noise-report`, `window_start`, `window_end`,
+`run_date` (= `wend`), and the metrics from `report` (`total_events`,
 `total_triggers`, `total_flaps`, `prod_triggers`, `noisiest_monitor`,
-`noisiest_env`). Body: the ranking table, the human threads from step 3, and a
+`noisiest_env`). Body: the ranking table, the human threads for that window, and a
 2-4 sentence Reading that calls out prod events explicitly and what deserves a
 ticket or a mute-with-reason.
 
-If `output/reports/alert-noise/alert-noise.base` does not exist, create it (see
-the committed copy for the schema: filter `type == "alert-noise-report"`, one
-table view sorted by `run_date` DESC).
+If `alert-noise.base` does not exist, create it (see the committed copy: filter
+`type == "alert-noise-report"`, one table view sorted by `run_date` DESC).
 
-### 6. Update the wiki synthesis (LLM)
+### 6. Update the wiki synthesis (LLM, interactive runs only)
 
 In `wiki/company/fes-platform-alert-noise.md`: update the Chronic offenders list
 (carry entries forward, mark resolved ones), bump `last_compiled`. The trend
@@ -84,17 +103,30 @@ table updates itself from the base, no manual edit needed. If the page is
 missing, create it (domain `[fanatics, observability]`) and add it to
 `wiki/_indexes/fanatics.md` and `wiki/_indexes/observability.md`.
 
+**Scheduled/unattended runs SKIP this step** (chronic-offenders curation is a
+judgment call left for interactive review; the Base trend still updates itself).
+
 ### 7. Log
 
 Append a `compile` entry to `wiki/_log.md`.
+
+## Scheduled use (via /end-of-day)
+
+`/end-of-day` invokes this skill so it runs about weekly. It is self-gating:
+step 1 (`pending`) returns nothing on days when no new week has completed, so the
+daily cost is one script call. When a week has closed (or several, after a missed
+run), it generates each missing note. Under `--unattended` it runs non-interactive
+and best-effort: steps 1-5 and 7 only (skip step 6), writing local notes + a log
+line, no prompts. The Slack MCP is already pre-flighted by end-of-day Step 0.
 
 ## Backfill (multiple past weeks at once)
 
 To seed history, fetch a wide range and split it into weekly notes:
 
 1. Paginate the whole range with `latest`-boundary pagination (oldest = range
-   start epoch), collecting every saved page path. For a long range this is many
-   pages; delegate the fetch to a subagent so the dumps stay out of context.
+   start minus 24h for margin), collecting every saved page path. For a long
+   range this is many pages; delegate the fetch to a subagent so the dumps stay
+   out of context.
 2. `extract` all page files into one TSV (it dedupes across pages).
 3. Slice per week and run `report` on each slice, using fixed midnight-Thursday
    windows `[Thu 00:00, next Thu 00:00)` so every week is the same shape:

--- a/stow-packages/claude/.claude/skills/alert-noise-report/scripts/alert_noise.py
+++ b/stow-packages/claude/.claude/skills/alert-noise-report/scripts/alert_noise.py
@@ -41,10 +41,13 @@ def env_of(block):
     m = re.search(r"env:(inf-dev|dev|test|prod|fanapp-[a-z-]+-1)", block)
     if m:
         return ENV_MAP.get(m.group(1), m.group(1))
-    for tok, env in (("[inf-dev]", "inf-dev"), ("[dev]", "dev"), ("[test]", "test"),
-                     ("[prod]", "prod"), ("DEV", "dev"), ("TEST", "test"), ("PROD", "prod")):
+    for tok, env in (("[inf-dev]", "inf-dev"), ("[dev]", "dev"),
+                     ("[test]", "test"), ("[prod]", "prod")):
         if tok in block:
             return env
+    m = re.search(r"\b(DEV|TEST|PROD)\b", block)  # word-bounded so FANDEVX != dev
+    if m:
+        return {"DEV": "dev", "TEST": "test", "PROD": "prod"}[m.group(1)]
     return "unknown"
 
 
@@ -80,7 +83,8 @@ def monitor_of(title):
 def extract(paths):
     seen, rows = set(), []
     for path in paths:
-        text = open(path).read().replace("\\/", "/")
+        text = (open(path).read().replace("\\/", "/").replace("\\u2014", "-")
+                .replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&"))
         parts = MSG_SPLIT.split(text)
         for i in range(1, len(parts) - 2, 3):
             author, block = parts[i], parts[i + 2]
@@ -125,7 +129,8 @@ def aggregate(rows):
         for ts, status in events:
             if status in TRIGGER_STATES:
                 a["trig"] += 1
-                open_trigger = ts
+                if open_trigger is None:  # anchor to the episode's FIRST trigger
+                    open_trigger = ts     # (renotify/re-trigger must not reset it)
             elif status == "Warn":
                 a["warn"] += 1
             elif status == "Recovered":
@@ -187,6 +192,26 @@ def pending(out_dir, now_epoch):
         print("\t".join(map(str, r)))
 
 
+def _selfcheck():
+    """Guard the flap-pairing rule: a flap is a Recovered within 30m of the
+    episode's FIRST trigger, so a renotify mid-incident must not create one."""
+    rows = [
+        ("100", "Triggered", "m1", "test", "s"),      # quick flap
+        ("160", "Recovered", "m1", "test", "s"),      #   +60s  -> flap
+        ("1000", "Triggered", "m2", "test", "s"),     # long incident
+        ("8200", "Re-Triggered", "m2", "test", "s"),  #   +2h renotify
+        ("8600", "Recovered", "m2", "test", "s"),     #   +7600s from first trigger -> NOT a flap
+        ("20000", "Triggered", "m3", "test", "s"),    # slow recovery
+        ("28000", "Recovered", "m3", "test", "s"),    #   +8000s -> NOT a flap
+    ]
+    agg = aggregate(rows)
+    flaps = sum(a["flap"] for a in agg.values())
+    assert flaps == 1, f"expected 1 flap, got {flaps}"
+    assert agg[("m2", "test")]["trig"] == 2, "renotify must still count as 2 triggers"
+    assert agg[("m2", "test")]["flap"] == 0, "long incident must not be a flap"
+    print("selfcheck OK")
+
+
 def main():
     cmd = sys.argv[1] if len(sys.argv) > 1 else ""
     if cmd == "extract":
@@ -196,6 +221,8 @@ def main():
     elif cmd == "pending":
         now_epoch = float(sys.argv[3]) if len(sys.argv) > 3 else time.time()
         pending(sys.argv[2], now_epoch)
+    elif cmd == "selfcheck":
+        _selfcheck()
     else:
         sys.exit(__doc__)
 

--- a/stow-packages/claude/.claude/skills/alert-noise-report/scripts/alert_noise.py
+++ b/stow-packages/claude/.claude/skills/alert-noise-report/scripts/alert_noise.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Alert-noise extraction and ranking for #fes-platform-alerts.
+
+Each weekly run produces one dated report NOTE whose frontmatter carries the
+summary metrics; an Obsidian Base (alert-noise.base) renders those notes as a
+table so trends read down the columns over time. This script only parses Slack
+and computes one week's numbers - no persistent store, the notes are the store.
+
+Subcommands:
+  extract <page-file>...   Slack 'detailed' page dumps -> event TSV (stdout)
+  report  <tsv>            frontmatter metrics block + noise-ranking table (stdout)
+"""
+import re
+import sys
+from collections import defaultdict
+
+FLAP_WINDOW_S = 30 * 60
+TRIGGER_STATES = ("Triggered", "Re-Triggered", "No-Data")
+ENV_MAP = {"fanapp-dev-1": "dev", "fanapp-test-1": "test",
+           "fanapp-prod-1": "prod", "fanapp-inf-dev-1": "inf-dev"}
+
+# ---------- extract (Slack detailed-page dumps -> normalized events) ----------
+
+MSG_SPLIT = re.compile(r"=== Message from (.+?) \((U[A-Z0-9]+)\) at [^=]+===")
+TS_RE = re.compile(r"Message TS: (\d+\.\d+)")
+ATT_RE = re.compile(r"Attachment: (Triggered|Re-Triggered|Recovered|Warn|No data|No-Data): (.+?) \(https?://")
+
+
+def env_of(block):
+    m = (re.search(r"(?:kube_)?cluster_name%3A(fanapp-[a-z-]+-1)\b", block)
+         or re.search(r"(?:kube_)?cluster_name:(fanapp-[a-z-]+-1)\b", block)
+         or re.search(r"clustername:fanapp-(dev|test|prod|inf-dev)-1", block))
+    if m:
+        return ENV_MAP.get(m.group(1), m.group(1))
+    m = re.search(r"env:(inf-dev|dev|test|prod|fanapp-[a-z-]+-1)", block)
+    if m:
+        return ENV_MAP.get(m.group(1), m.group(1))
+    for tok, env in (("[inf-dev]", "inf-dev"), ("[dev]", "dev"), ("[test]", "test"),
+                     ("[prod]", "prod"), ("DEV", "dev"), ("TEST", "test"), ("PROD", "prod")):
+        if tok in block:
+            return env
+    return "unknown"
+
+
+def service_of(block):
+    m = re.search(r"[Ss]ervice%3A([a-z0-9-]+)", block) or re.search(r"service:([a-z0-9-]+)", block)
+    if m:
+        return m.group(1)
+    m = re.search(r"kube_namespace%3A([a-z0-9-]+)", block) or re.search(r"kube_namespace:([a-z0-9-]+)", block)
+    if m:
+        return m.group(1)
+    m = re.search(r"pod_name:([a-z0-9-]+)", block)
+    if m:
+        return re.sub(r"(-[a-f0-9]{8,10})?-[a-z0-9]{5}$", "", m.group(1))
+    m = re.search(r"kube_deployment:([a-z0-9-]+)", block)
+    if m:
+        return m.group(1)
+    m = re.search(r"\bname:([a-z0-9.-]+)", block)
+    if m:
+        return m.group(1)
+    return "-"
+
+
+def monitor_of(title):
+    title = re.sub(r":[a-z0-9_+-]+:\s*", "", title)  # strip slack emoji shortcodes
+    title = re.sub(r" on (kube_cluster_name|env|[a-z_]+):.*$", "", title)
+    title = re.sub(r" - fanapp-[a-z-]+-1$", "", title)
+    title = re.sub(r" - [a-z0-9-]+/[a-z0-9-]+$", "", title)
+    title = re.sub(r"\s+-\s+/\s*$", "", title)
+    title = re.sub(r"^\[(dev|test|prod|inf-dev|fanapp-[a-z-]+-1)\]\s*", "", title)
+    return title.strip()
+
+
+def extract(paths):
+    seen, rows = set(), []
+    for path in paths:
+        text = open(path).read().replace("\\/", "/")
+        parts = MSG_SPLIT.split(text)
+        for i in range(1, len(parts) - 2, 3):
+            author, block = parts[i], parts[i + 2]
+            if author != "Datadog":
+                continue
+            ts_m, att_m = TS_RE.search(block), ATT_RE.search(block)
+            if not ts_m or not att_m or ts_m.group(1) in seen:
+                continue
+            seen.add(ts_m.group(1))
+            status = att_m.group(1).replace("No data", "No-Data")
+            rows.append((ts_m.group(1), status, monitor_of(att_m.group(2)), env_of(block), service_of(block)))
+    rows.sort(key=lambda r: float(r[0]))
+    for r in rows:
+        print("\t".join(r))
+
+
+# ---------- report (TSV -> summary metrics + ranking table) ----------
+
+def load(tsv_path):
+    rows = []
+    with open(tsv_path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            assert len(parts) == 5, f"bad row: {line!r}"
+            rows.append(parts)
+    rows.sort(key=lambda r: float(r[0]))
+    return rows
+
+
+def aggregate(rows):
+    groups = defaultdict(list)
+    for ts, status, monitor, env, service in rows:
+        groups[(monitor, env, service)].append((float(ts), status))
+    agg = defaultdict(lambda: {"trig": 0, "rec": 0, "warn": 0, "flap": 0, "services": set()})
+    for (monitor, env, service), events in groups.items():
+        a = agg[(monitor, env)]
+        a["services"].add(service)
+        open_trigger = None
+        for ts, status in events:
+            if status in TRIGGER_STATES:
+                a["trig"] += 1
+                open_trigger = ts
+            elif status == "Warn":
+                a["warn"] += 1
+            elif status == "Recovered":
+                a["rec"] += 1
+                if open_trigger is not None and ts - open_trigger <= FLAP_WINDOW_S:
+                    a["flap"] += 1
+                open_trigger = None
+    return agg
+
+
+def report(tsv_path):
+    rows = load(tsv_path)
+    agg = aggregate(rows)
+    total_trig = sum(a["trig"] for a in agg.values())
+    total_flap = sum(a["flap"] for a in agg.values())
+    prod_trig = sum(a["trig"] for (m, e), a in agg.items() if e == "prod")
+    (nm, ne), _ = max(agg.items(), key=lambda kv: kv[1]["trig"]) if agg else (("-", "-"), None)
+
+    print("# frontmatter metrics (copy into the report note)")
+    print(f"total_events: {len(rows)}")
+    print(f"total_triggers: {total_trig}")
+    print(f"total_flaps: {total_flap}")
+    print(f"prod_triggers: {prod_trig}")
+    print(f'noisiest_monitor: "{nm}"')
+    print(f"noisiest_env: {ne}")
+    print()
+    print("# noise ranking (copy into the report note body)")
+    print("| Monitor | Env | Triggers | Recoveries | Flaps (<30m) | Services/groups |")
+    print("|---|---|---|---|---|---|")
+    for (monitor, env), a in sorted(agg.items(), key=lambda kv: -kv[1]["trig"]):
+        svc_list = sorted(s for s in a["services"] if s != "-")
+        svcs = ", ".join(svc_list[:4]) or "-"
+        if len(svc_list) > 4:
+            svcs += f" (+{len(svc_list) - 4} more)"
+        print(f"| {monitor} | {env} | {a['trig']} | {a['rec']} | {a['flap']} | {svcs} |")
+
+
+def main():
+    if len(sys.argv) < 3 or sys.argv[1] not in ("extract", "report"):
+        sys.exit(__doc__)
+    if sys.argv[1] == "extract":
+        extract(sys.argv[2:])
+    else:
+        report(sys.argv[2])
+
+
+if __name__ == "__main__":
+    main()

--- a/stow-packages/claude/.claude/skills/alert-noise-report/scripts/alert_noise.py
+++ b/stow-packages/claude/.claude/skills/alert-noise-report/scripts/alert_noise.py
@@ -7,12 +7,18 @@ table so trends read down the columns over time. This script only parses Slack
 and computes one week's numbers - no persistent store, the notes are the store.
 
 Subcommands:
-  extract <page-file>...   Slack 'detailed' page dumps -> event TSV (stdout)
-  report  <tsv>            frontmatter metrics block + noise-ranking table (stdout)
+  extract <page-file>...      Slack 'detailed' page dumps -> event TSV (stdout)
+  report  <tsv>               frontmatter metrics block + noise-ranking table (stdout)
+  pending <out-dir> [now]     completed Thu-weeks with no note yet, one per line:
+                              wend  wstart  margin_oldest  window_start  window_end
+                              (epochs; margin = window_start - 24h fetch overlap)
 """
+import os
 import re
 import sys
+import time
 from collections import defaultdict
+from datetime import datetime, timedelta
 
 FLAP_WINDOW_S = 30 * 60
 TRIGGER_STATES = ("Triggered", "Re-Triggered", "No-Data")
@@ -157,13 +163,41 @@ def report(tsv_path):
         print(f"| {monitor} | {env} | {a['trig']} | {a['rec']} | {a['flap']} | {svcs} |")
 
 
+def pending(out_dir, now_epoch):
+    """Completed Thu-weeks (window [Thu 00:00, next Thu 00:00)) that have no note.
+
+    Walks back from the most recently completed week until it hits a week that
+    already has a note (older weeks are assumed present) or a 14-week cap.
+    """
+    now = datetime.fromtimestamp(now_epoch)
+    d = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    while d.weekday() != 3:  # 3 = Thursday; most recent completed week-end
+        d -= timedelta(days=1)
+    rows = []
+    for i in range(14):
+        wend_dt = d - timedelta(days=7 * i)
+        wend = wend_dt.strftime("%Y-%m-%d")
+        if os.path.exists(os.path.join(out_dir, wend + ".md")):
+            break
+        wstart_dt = wend_dt - timedelta(days=7)
+        margin_dt = wstart_dt - timedelta(days=1)
+        rows.append((wend, wstart_dt.strftime("%Y-%m-%d"),
+                     int(margin_dt.timestamp()), int(wstart_dt.timestamp()), int(wend_dt.timestamp())))
+    for r in reversed(rows):  # oldest first
+        print("\t".join(map(str, r)))
+
+
 def main():
-    if len(sys.argv) < 3 or sys.argv[1] not in ("extract", "report"):
-        sys.exit(__doc__)
-    if sys.argv[1] == "extract":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+    if cmd == "extract":
         extract(sys.argv[2:])
-    else:
+    elif cmd == "report":
         report(sys.argv[2])
+    elif cmd == "pending":
+        now_epoch = float(sys.argv[3]) if len(sys.argv) > 3 else time.time()
+        pending(sys.argv[2], now_epoch)
+    else:
+        sys.exit(__doc__)
 
 
 if __name__ == "__main__":

--- a/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
+++ b/stow-packages/claude/.claude/skills/end-of-day/SKILL.md
@@ -119,6 +119,9 @@ behavior, not an error.
   Step 9 daily-note Follow-ups for the next interactive session.
 - **Step 7 (compile):** run non-interactively. (If the compile sub-skill exposes
   any prompt, take its default.)
+- **Step 8.7 (alert-noise weekly):** local writes (report notes + a log line) are
+  allowed unattended. Run non-interactively and catch-up; skip the skill's
+  wiki-synthesis step. `pending` returning nothing is `nothing-to-do`, not a failure.
 - **Step 9 (daily-note synthesis):** auto-approve and write the drafted section.
   The upsert and `grep -c '<!-- eod:begin'` post-write check are unchanged. If
   the check returns `0` or `>1`, do NOT proceed silently: record a failure
@@ -188,6 +191,10 @@ Step 8: Verify-Status                 Run /verify-status read-only snapshot — 
 
 Step 8.5: Work-board drift report     Run /work-board --dry-run --stale-days 7 — surface pending
                                       moves, manual overrides, orphans, stale + sectionless cards
+
+Step 8.7: Alert-Noise Weekly          Generate #fes-platform-alerts noise report(s) for any completed
+                                      week that lacks one (alert-noise-report, self-gating catch-up;
+                                      writes local report notes only)
 
 Step 9: Daily-Note Synthesis          Draft today's EOD section into the daily note:
                                       accomplishments, decisions, follow-ups, tomorrow,
@@ -503,6 +510,36 @@ Next Up / In Progress with no Todoist activity in 7 days - ask whether each is s
 and any sectionless cards in the Work project
 (`td task list --project "Work" --json` entries with null sectionId) as filing candidates.
 
+### Step 8.7: Alert-Noise Weekly (catch-up)
+
+Generate the weekly #fes-platform-alerts noise report when a new week has closed.
+Self-gating and cheap on days with nothing to do.
+
+Invoke the `alert-noise-report` skill (catch-up is its default). It runs its
+`pending` check first: on most days that returns nothing and this step is
+`nothing-to-do`. When one or more completed Thursday-weeks lack a note, it fetches
+those windows (with a 24h overlap margin so no boundary events are clipped),
+writes one dated report note per week to `output/reports/alert-noise/`, and
+appends a `wiki/_log.md` line. Do NOT run the skill's wiki-synthesis step here
+(chronic-offenders curation is left for standalone interactive runs); the Obsidian
+Base renders the trend from the notes automatically.
+
+```
+Skill: alert-noise-report
+Args: (none - catch-up default; generate pending week notes only, skip wiki synthesis)
+```
+
+Slack MCP is already verified in Step 0. This writes local files only (report
+notes + a log line), so it is safe unattended.
+
+Track: weeks generated (with event / trigger counts) or `nothing-to-do`.
+
+Record status:
+
+- `ok` - one or more week notes written
+- `nothing-to-do` - no completed week was missing a note
+- `failed` - see Error Handling
+
 ### Step 9: Daily-Note Synthesis
 
 Draft today's end-of-day section into the daily note. Interactive: present the draft for approve / edit / skip before writing.
@@ -660,6 +697,9 @@ End-of-Day Complete
     NEXT: merge PR #1842 (approved, clean, mine)
     Drift findings: 1 (load-testing-environment/log.md stale-pr)
 
+  Step 8.7 - Alert-Noise Weekly:
+    Weeks generated: 1 (2026-07-09: 62 events, 40 triggers)  [or: nothing-to-do]
+
   Step 9 — Daily-Note Synthesis:
     Daily note: <output of obsidian daily:path>
     Sections written: standard + Friday weekly retro
@@ -681,6 +721,7 @@ Then append an end-of-day block to `wiki/_log.md`:
 - Project-log gate: 4 audited, 2 missing entries, 2 created
 - Compile: 4 created, 2 updated, 7 new connections
 - Verify-status: NEXT: merge PR #1842; 1 drift finding
+- Alert-noise weekly: 1 week generated (2026-07-09) [or nothing-to-do]
 - Daily-note synthesis: standard + Friday weekly retro (approved)
 - Step failures: none
 ```
@@ -754,6 +795,7 @@ If a background subagent was still running when the interrupt happened, mark it 
 - **/lyt-assistant:internal-channel-learnings** — Internal channel → `raw/internal_learnings/` (Step 4)
 - **/lyt-assistant:meeting-action-items** — Interactive review of meeting action items into Todoist (Step 5)
 - **/lyt-assistant:compile** — Full compilation pipeline (Step 6; itself chains `/lyt-assistant:ingest` → `/lyt-assistant:lint` → `/lyt-assistant:discover-links`)
+- **/alert-noise-report** - #fes-platform-alerts weekly noise report; self-gating catch-up (Step 8.7)
 - **/start-of-day** — Morning counterpart; lists today + overdue Todoist tasks with an inline edit loop (user-private skill at `~/.claude/skills/start-of-day/`)
 
 ## Summary


### PR DESCRIPTION
## What

Adds an `alert-noise-report` skill and wires it into `/end-of-day` as a weekly, self-gating step. The skill turns the #fes-platform-alerts Datadog stream into dated Obsidian report notes rendered as a Base for week-over-week trends. Storage is the notes themselves (no separate database); the Base renders the trend.

## Components

- `scripts/alert_noise.py` (stdlib only): `extract` (Slack detailed-page dumps to event TSV), `report` (per monitor/env triggers, recoveries, flaps within 30m, plus a frontmatter metrics block), `pending` (completed Thursday-weeks lacking a note, each with a 24h fetch margin), and `selfcheck` (asserts the flap rule).
- `alert-noise-report/SKILL.md`: catch-up-by-default workflow, backfill procedure, scheduled-use notes.
- `end-of-day/SKILL.md`: new Step 8.7. Self-gating (near-zero cost on days when no week has closed), catch-up across missed runs, non-interactive, local report-note writes only. Runs on Thursdays (the day each week closes); the Slack MCP is already gated by EOD Step 0.

## How overlap/dedupe is handled

Each weekly note is a full recompute of a fixed `[Thu 00:00, next Thu 00:00)` window from a fresh fetch, not an incremental delta. Extraction dedupes by Slack message timestamp and the slice is half-open, so events cannot be double-counted; the 24h fetch margin guarantees boundary events are never clipped.

## Testing

- `pending` checked in three states: empty in steady state, one week after Thursday, two-week catch-up after a missed run.
- Headless path validated via a non-interactive agent (Slack MCP reachable, no prompts).
- Backfilled the channel's full history and verified it against an independent fresh re-fetch (every week matched).
- Local code review run pre-PR: it caught a flap over-count (a renotify mid-incident followed by a quick recovery was miscounted as a flap) and an `env_of` mis-tag risk (`FANDEVX` matching `dev`). Both fixed here; a `selfcheck` subcommand guards the flap rule.

Generated with [Claude Code](https://claude.com/claude-code)
