### PR TITLE
feat(decompose-ticket): add skill to break a Jira ticket into child work items

### DIFF
--- a/stow-packages/claude/.claude/skills/decompose-ticket/SKILL.md
+++ b/stow-packages/claude/.claude/skills/decompose-ticket/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: decompose-ticket
+description: Use when the user wants to break a Jira Feature, Epic, or Story down one level into child work items for the FES Platform team: Feature into epics, Epic into stories, Story into sub-tasks (FANDEVX/FESFEAT). Triggers on "decompose", "break down this feature/epic/story", "split this ticket into children", "generate the epics/stories/subtasks for". Not for creating a single standalone ticket.
+---
+
+# Decompose Ticket
+
+## Overview
+
+Break one Jira parent (Feature, Epic, or Story) into its immediate children (one level only), then create those children under the parent.
+
+A capable agent can already list plausible children and pick the right issue type. The value of this skill is the *process* around that list: real research, an adversarial review pass, and a mandatory confirmation gate before anything is written to Jira. Follow the pipeline; do not shortcut to "here are the children, created."
+
+Tiers: Feature → Epics · Epic → Stories · Story → Sub-tasks. One level, never recurse.
+
+## When to use
+
+- "Decompose / break down / split" a Feature, Epic, or Story into children.
+- Generate the child epics / stories / sub-tasks *and create them* under a parent.
+
+Not for: a single standalone ticket (use `fes-platform-jira-tickets`); a Bug or an existing Sub-task, which the classifier refuses (nothing to decompose).
+
+## Pipeline
+
+Run in order. REQUIRED steps stay in even when the breakdown "looks obvious"; those are exactly the steps a one-shot agent drops.
+
+1. **Fetch & classify.** `getJiraIssue` (fields: summary, description, status, issuetype, subtasks, parent, comment, issuelinks). Get the child tier and routing from the script, do not hand-map:
+
+   ```bash
+   scripts/classify-ticket.sh "<parent issue type>"   # relative to this skill's base dir
+   ```
+
+   Prints `child_type`, `child_project`, `creator`; or exits 2 with a reason (Bug / Sub-task / unsupported, so stop and tell the user why). If the parent already has children of `child_type`, show them and ask augment-vs-abort. Warn if the parent is Done/closed.
+
+2. **Research the parent (REQUIRED).** Wiki-first (`~/Documents/Work/wiki/_index.md`), then Confluence/Jira, then web. Choose 3-5 angles tailored to *splitting the work*: definition-of-done, system/codebase touchpoints, dependencies & sequencing, risks/unknowns/spikes, prior similar tickets. Dispatch one general-purpose agent per angle in a single message (tools: WebSearch, WebFetch, Grep, Read, Atlassian search); each returns sourced atomic findings. Synthesize a short brief: what the work entails, the natural seams to split on, cross-child dependencies, risks. The brief, not the ticket text alone, grounds the plan.
+
+3. **Draft the plan.** Write a plan file to `~/.claude/plans/decompose-<KEY>-plan.md` (mkdir -p if needed; this is where `adversarial-review` looks by default) with a `## Context` section (so the reviewer reads it) and, per child: title, context, **AC**, **implementation hints** where applicable, one-line rationale. Add sibling sequencing and an explicit out-of-scope list.
+
+4. **Adversarial review, max 2 rounds (REQUIRED).** Run the `adversarial-review` skill on the plan file. Auto-incorporate the consolidated findings each round; re-run once if round 1 produced any; stop at 2. (This automates that skill's cherry-pick prompt; the value kept is the parallel red-team, not the interactivity.)
+
+5. **Confirm before creating (REQUIRED GATE).** Present the final children (title / AC / hints / child_type, plus the fields you will set: sprint, priority, work category, and the parent link), then AskUserQuestion: **Create all / Edit first / Cancel.** Create nothing before an explicit yes. Creating Jira tickets is outward-facing and hard to reverse; this is the one hard gate.
+
+6. **Create the children**, routed by `creator`:
+   - `jira-skill` (Epics, Stories): follow the `fes-platform-jira-tickets` contract. Read its `references/jira_config.md` at runtime for current field IDs; never hardcode them here. Fetch the active sprint once and reuse. Set the parent via the native `parent` param. Work Category is REQUIRED on Stories. After each create, run the `editJiraIssue` markdown-fix (REQUIRED every time) or the description renders as raw source.
+   - `direct-mcp-subtask` (Sub-tasks): `createJiraIssue` with `issueTypeName: "Sub-task"`, `parent: "<story-key>"`. **Omit** `customfield_10001` (Team); the API rejects it on sub-tasks. Fetch the Sub-task createmeta (`getJiraIssueTypeMetaWithFields`) to set exactly the required fields; don't guess. Then the same markdown-fix `editJiraIssue`.
+
+7. **Summarize & log.** Print the parent plus each child key + URL and confirm linkage. If the parent maps to a `~/Documents/Work/projects/<name>/` folder, append a `log.md` entry. Don't comment on the parent ticket unless asked.
+
+## Quick reference
+
+| Parent | Child | Created via |
+|--------|-------|-------------|
+| Feature (FESFEAT) | Epic | fes-platform-jira-tickets |
+| Epic | Story | fes-platform-jira-tickets |
+| Story | Sub-task | direct Atlassian MCP (omit Team field) |
+| Bug / Sub-task | n/a | refuse, nothing to decompose |
+
+## Common mistakes
+
+- **Skipping research or review because the split "looks obvious."** Those are the two steps a one-shot agent drops, and the reason this skill exists. REQUIRED.
+- **Creating tickets before the gate.** Never. Present, then wait for an explicit Create all.
+- **Story → Task.** A Task is level 0, a sibling of Story, not a child; the child of a Story is a Sub-task. The classifier enforces this, so use it, don't hand-map.
+- **Forgetting the `editJiraIssue` markdown-fix** after create; descriptions render as raw source without it.
+- **Setting the Team field on a sub-task**; the create call fails. Omit it.
+- **Recursing past one level.** Decompose only the immediate tier.
+
+## Validating changes to this skill
+
+The mapping, routing, and guards have a runnable test. Red/green it before touching `classify-ticket.sh`:
+
+```bash
+bash scripts/classify-ticket.test.sh
+```

--- a/stow-packages/claude/.claude/skills/decompose-ticket/scripts/classify-ticket.sh
+++ b/stow-packages/claude/.claude/skills/decompose-ticket/scripts/classify-ticket.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# classify-ticket.sh — decision core for the decompose-ticket skill.
+# Maps a parent Jira issue type to its one-level-down child tier and the
+# routing used to create that child, or refuses (exit 2) when the type is not
+# decomposable within this skill's scope.
+#
+# stdout (exit 0): three key=value lines — child_type, child_project, creator.
+# stderr (exit 2): a one-line reason.
+#
+# creator routing:
+#   jira-skill          -> create via the fes-platform-jira-tickets contract
+#   direct-mcp-subtask  -> create via direct Atlassian MCP (that skill has no
+#                          sub-task path); omit the Team field per FANDEVX rules.
+#
+# ponytail: scope is Feature/Epic/Story only (the requested tiers). Task is
+# refused even though Task->Sub-task is valid — add a `task)` case if that need
+# ever shows up rather than guessing at it now.
+set -u
+
+[ "$#" -eq 1 ] || { echo "usage: classify-ticket.sh <parent-issue-type>" >&2; exit 2; }
+
+# normalize: lowercase, strip whitespace, unify sub-task spellings
+t="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+case "$t" in subtask) t="sub-task" ;; esac
+
+case "$t" in
+  feature)
+    echo "child_type=Epic"
+    echo "child_project=FANDEVX"
+    echo "creator=jira-skill"
+    ;;
+  epic)
+    echo "child_type=Story"
+    echo "child_project=FANDEVX"
+    echo "creator=jira-skill"
+    ;;
+  story)
+    echo "child_type=Sub-task"
+    echo "child_project=FANDEVX"
+    echo "creator=direct-mcp-subtask"
+    ;;
+  bug)
+    echo "not decomposable: Bug is a leaf work item with no child tier." >&2
+    exit 2
+    ;;
+  sub-task)
+    echo "not decomposable: Sub-task is already the lowest hierarchy level." >&2
+    exit 2
+    ;;
+  "")
+    echo "no issue type provided." >&2
+    exit 2
+    ;;
+  *)
+    echo "unsupported issue type: '$1' (decomposes Feature, Epic, or Story only)." >&2
+    exit 2
+    ;;
+esac

--- a/stow-packages/claude/.claude/skills/decompose-ticket/scripts/classify-ticket.test.sh
+++ b/stow-packages/claude/.claude/skills/decompose-ticket/scripts/classify-ticket.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Red/green test for classify-ticket.sh — the mechanical decision core of the
+# decompose-ticket skill. Locks the parent->child mapping, the creation routing,
+# and the decomposability guards so they never regress to the "Story -> Task"
+# mistake a capable agent might still make on a bad day.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SUT="$HERE/classify-ticket.sh"
+pass=0
+fail=0
+
+# assert_kv <parent-type> <expected key=value line>
+# passes when the script exits 0 and prints that exact line
+assert_kv() {
+  local input="$1" expect="$2" out rc
+  out="$(bash "$SUT" "$input" 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -qxF "$expect"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: classify %-10s -> want "%s" (rc 0); got rc=%s:\n%s\n' \
+      "$input" "$expect" "$rc" "$out" >&2
+  fi
+}
+
+# assert_refuse <parent-type>
+# passes when the script exits 2 (not decomposable / unsupported / missing)
+assert_refuse() {
+  local input="$1" out rc
+  out="$(bash "$SUT" "$input" 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: classify %-10s -> want refusal (rc 2); got rc=%s:\n%s\n' \
+      "$input" "$rc" "$out" >&2
+  fi
+}
+
+# --- the contract ---
+assert_kv     "Feature"  "child_type=Epic"
+assert_kv     "Feature"  "creator=jira-skill"
+assert_kv     "Epic"     "child_type=Story"
+assert_kv     "epic"     "creator=jira-skill"          # case-insensitive
+assert_kv     "Story"    "child_type=Sub-task"         # the historically mis-specified case
+assert_kv     "Story"    "creator=direct-mcp-subtask"  # sub-tasks bypass the jira-tickets skill
+assert_refuse "Bug"                                    # leaf, nothing to decompose
+assert_refuse "Sub-task"                               # already lowest level
+assert_refuse "Task"                                   # out of scope (level-0, not Feature/Epic/Story)
+assert_refuse ""                                       # nothing supplied
+assert_refuse "Widget"                                 # unknown type
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

New user skill `decompose-ticket`: breaks a Jira Feature, Epic, or Story down one level into child work items for the FES Platform team.

- Feature -> Epics, Epic -> Stories, Story -> Sub-tasks (one level, no recursion)
- Pipeline: fetch + classify -> research (parallel fan-out, wiki-first) -> draft plan -> adversarial-review (max 2 rounds) -> confirmation gate -> create children
- Reuses the `adversarial-review` skill and the `fes-platform-jira-tickets` creation contract. Sub-tasks are created via direct Atlassian MCP, since that skill has no sub-task path (and the Team field is omitted, which the API rejects on sub-tasks).

## Why

Makes ticket decomposition a repeatable, reviewed process instead of a one-shot list. A capable agent already picks the right child type on its own, but skips external research, any adversarial review, and a pre-creation gate; the skill makes those steps non-optional.

## How verified (red/green)

- Mechanical: the parent->child mapping, routing, and guards live in `scripts/classify-ticket.sh`, covered by an assert test `scripts/classify-ticket.test.sh`. A naive stub failed 7 cases including `Story -> Task`; the real implementation passes 11/11.
- Behavioral: a subagent decomposing a mock Story with no skill skipped research, review, and the gate. With the skill it ran the classifier, produced correct Sub-tasks, and stopped at the confirmation gate.

Deployed as a stow symlink under `~/.claude/skills/decompose-ticket`.

Generated with Claude Code: <https://claude.com/claude-code>
